### PR TITLE
🐇 feat(core,desktop): mDNS discovery, device revocation, enhanced tray menu

### DIFF
--- a/apps/desktop/src/bun/index.ts
+++ b/apps/desktop/src/bun/index.ts
@@ -4,7 +4,14 @@
 // Docs: https://blackboard.sh/electrobun/docs/
 
 import { existsSync } from 'node:fs'
-import { generateToken, getOrCreateIdentity, loadConfig, startServer } from '@warren/core'
+import {
+  generateToken,
+  getOrCreateIdentity,
+  listPairedDevices,
+  loadConfig,
+  startServer,
+  updateConfig,
+} from '@warren/core'
 import { BrowserWindow, Tray } from 'electrobun/bun'
 
 // ---------------------------------------------------------------------------
@@ -35,6 +42,31 @@ console.log(`[warren] Public key: ${identity.publicKey}`)
 // Tray
 // ---------------------------------------------------------------------------
 
+let hostMode = config.hostMode
+
+function buildTrayMenu() {
+  const devices = listPairedDevices()
+  const activeCount = devices.filter((d) => d.permission === 'full').length
+
+  return [
+    {
+      type: 'normal' as const,
+      label: `Host Mode: ${hostMode ? 'On' : 'Off'}`,
+      action: 'toggle-host',
+    },
+    {
+      type: 'normal' as const,
+      label: `Devices: ${activeCount} paired`,
+      action: 'noop',
+    },
+    { type: 'separator' as const },
+    { type: 'normal' as const, label: 'Show QR Code', action: 'qr' },
+    { type: 'normal' as const, label: 'Open Dashboard', action: 'dashboard' },
+    { type: 'separator' as const },
+    { type: 'normal' as const, label: 'Quit Warren', action: 'quit' },
+  ]
+}
+
 // TODO: Convert iconTemplate.svg to a 32x32 PNG template image for macOS
 const tray = new Tray({
   image: 'views://assets/iconTemplate.svg',
@@ -42,11 +74,11 @@ const tray = new Tray({
   title: '',
 })
 
-tray.setMenu([
-  { type: 'normal', label: 'Open Dashboard', action: 'dashboard' },
-  { type: 'separator' },
-  { type: 'normal', label: 'Quit Warren', action: 'quit' },
-])
+function refreshTray(): void {
+  tray.setMenu(buildTrayMenu())
+}
+
+refreshTray()
 
 tray.on('tray-clicked', () => {
   toggleDashboard()
@@ -60,8 +92,19 @@ tray.on('tray-item-clicked', (_event) => {
     server.stop()
     tray.remove()
     process.exit(0)
+  } else if (action === 'toggle-host') {
+    hostMode = !hostMode
+    updateConfig({ hostMode })
+    refreshTray()
+    console.log(`[warren] Host mode: ${hostMode ? 'on' : 'off'}`)
+  } else if (action === 'qr') {
+    showDashboard()
+    // The dashboard will auto-trigger pairing QR display
   }
 })
+
+// Refresh tray menu periodically to update device count
+const trayRefreshInterval = setInterval(refreshTray, 30_000)
 
 // ---------------------------------------------------------------------------
 // Dashboard Window
@@ -103,6 +146,7 @@ function toggleDashboard(): void {
 console.log('[warren] App ready. Click the tray icon to open the dashboard.')
 
 process.on('SIGTERM', () => {
+  clearInterval(trayRefreshInterval)
   server.stop()
   tray.remove()
   process.exit(0)

--- a/apps/desktop/src/bun/index.ts
+++ b/apps/desktop/src/bun/index.ts
@@ -80,26 +80,29 @@ function refreshTray(): void {
 
 refreshTray()
 
-tray.on('tray-clicked', () => {
-  toggleDashboard()
-})
+tray.on('tray-clicked', (event) => {
+  const action = event.data?.action
 
-tray.on('tray-item-clicked', (_event) => {
-  const action = _event?.data?.action
-  if (action === 'dashboard') {
-    showDashboard()
-  } else if (action === 'quit') {
-    server.stop()
-    tray.remove()
-    process.exit(0)
-  } else if (action === 'toggle-host') {
-    hostMode = !hostMode
-    updateConfig({ hostMode })
-    refreshTray()
-    console.log(`[warren] Host mode: ${hostMode ? 'on' : 'off'}`)
-  } else if (action === 'qr') {
-    showDashboard()
-    // The dashboard will auto-trigger pairing QR display
+  switch (action) {
+    case 'dashboard':
+      showDashboard()
+      break
+    case 'quit':
+      server.stop()
+      tray.remove()
+      process.exit(0)
+      break
+    case 'toggle-host':
+      hostMode = !hostMode
+      updateConfig({ hostMode })
+      refreshTray()
+      console.log(`[warren] Host mode: ${hostMode ? 'on' : 'off'}`)
+      break
+    case 'qr':
+      showDashboard()
+      break
+    default:
+      break
   }
 })
 
@@ -128,15 +131,6 @@ function showDashboard(): void {
   dashboardWindow.on('close', () => {
     dashboardWindow = null
   })
-}
-
-function toggleDashboard(): void {
-  if (dashboardWindow) {
-    dashboardWindow.close()
-    dashboardWindow = null
-  } else {
-    showDashboard()
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/dashboard/index.ts
+++ b/apps/desktop/src/dashboard/index.ts
@@ -68,6 +68,10 @@ const api = {
     return request<DeviceInfo[]>('/api/devices')
   },
 
+  revokeDevice(id: string): Promise<{ ok: boolean }> {
+    return request<{ ok: boolean }>(`/api/devices/${id}/revoke`, { method: 'PATCH' })
+  },
+
   deleteDevice(id: string): Promise<{ ok: boolean }> {
     return request<{ ok: boolean }>(`/api/devices/${id}`, { method: 'DELETE' })
   },

--- a/apps/desktop/types/electrobun.d.ts
+++ b/apps/desktop/types/electrobun.d.ts
@@ -22,13 +22,13 @@ declare module 'electrobun/bun' {
     action?: string
   }
 
+  export interface TrayClickedEvent {
+    data?: { id: number; action: string; data?: unknown }
+  }
+
   export class Tray {
     constructor(options?: TrayOptions)
-    on(event: 'tray-clicked', handler: () => void): this
-    on(
-      event: 'tray-item-clicked',
-      handler: (event: { data?: { action?: string } }) => void,
-    ): this
+    on(event: 'tray-clicked', handler: (event: TrayClickedEvent) => void): this
     setTitle(title: string): void
     setImage(image: string): void
     setMenu(items: TrayMenuItem[]): void

--- a/bun.lock
+++ b/bun.lock
@@ -89,6 +89,7 @@
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@warren/types": "workspace:*",
+        "bonjour-service": "^1.3.0",
         "qrcode-terminal": "^0.12.0",
       },
       "devDependencies": {
@@ -368,6 +369,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
 
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@1.1.1", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ=="],
 
@@ -723,6 +726,8 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
+    "bonjour-service": ["bonjour-service@1.3.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "multicast-dns": "^7.2.5" } }, "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA=="],
+
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
@@ -862,6 +867,8 @@
     "direction": ["direction@2.0.1", "", { "bin": { "direction": "cli.js" } }, "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="],
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
+
+    "dns-packet": ["dns-packet@5.6.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.1" } }, "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw=="],
 
     "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
@@ -1367,6 +1374,8 @@
 
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
 
+    "multicast-dns": ["multicast-dns@7.2.5", "", { "dependencies": { "dns-packet": "^5.2.2", "thunky": "^1.0.2" }, "bin": { "multicast-dns": "cli.js" } }, "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg=="],
+
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -1680,6 +1689,8 @@
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
     "three": ["three@0.165.0", "", {}, "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA=="],
+
+    "thunky": ["thunky@1.1.0", "", {}, "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@warren/types": "workspace:*",
+    "bonjour-service": "^1.3.0",
     "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -36,7 +36,7 @@ export function advertise(info: WarrenServiceInfo): void {
 
   const bonjour = getBonjourInstance()
   publishedService = bonjour.publish({
-    name: `Warren - ${info.hostName}`,
+    name: `warren-${info.hostName}`,
     type: 'warren',
     port: info.port,
     txt: {

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -5,12 +5,19 @@
 // TXT records: version, nodeId, hostName, hostMode
 
 import type { WarrenServiceInfo } from '@warren/types'
-import Bonjour, { type Service } from 'bonjour-service'
+import BonjourModule, { type Service } from 'bonjour-service'
 
-let bonjourInstance: InstanceType<typeof Bonjour> | null = null
+// bonjour-service is CJS — handle both ESM default and direct export
+const Bonjour =
+  typeof BonjourModule === 'function'
+    ? BonjourModule
+    : (BonjourModule as { default: typeof BonjourModule }).default
+
+type BonjourInstance = InstanceType<typeof Bonjour>
+let bonjourInstance: BonjourInstance | null = null
 let publishedService: Service | null = null
 
-function getBonjourInstance(): InstanceType<typeof Bonjour> {
+function getBonjourInstance(): BonjourInstance {
   if (!bonjourInstance) {
     bonjourInstance = new Bonjour()
   }

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -19,7 +19,10 @@ let publishedService: Service | null = null
 
 function getBonjourInstance(): BonjourInstance {
   if (!bonjourInstance) {
-    bonjourInstance = new Bonjour()
+    // reuseAddr: share port 5353 with macOS's built-in mDNSResponder
+    // instead of fighting over it (which triggers hostname conflict dialogs).
+    // The opts object is passed through to multicast-dns which supports reuseAddr.
+    bonjourInstance = new Bonjour({ reuseAddr: true } as Record<string, unknown>)
   }
   return bonjourInstance
 }

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -1,63 +1,148 @@
 // Discovery — Bonjour/mDNS service advertisement and discovery
 //
-// Plan for v0.2 implementation:
-//   Option A (preferred): Use the `bonjour-service` npm package which wraps
-//     native mDNS. It provides advertise() / find() APIs with a callback model.
-//     Install: bun add bonjour-service
-//
-//   Option B: Use `@homebridge/dbus-native` + Avahi (Linux) for native D-Bus
-//     integration. macOS uses the built-in mDNSResponder.
-//
-//   Option C: Call `dns_sd` C library via Bun's FFI (bun:ffi) for truly native
-//     macOS Bonjour without a wrapper. Most performant, but more complex.
-//
+// Uses `bonjour-service` for cross-platform mDNS.
 // Service type: _warren._tcp
-// TXT records: version, nodeId, hostName, hostMode, port
-//
-// See: https://developer.apple.com/bonjour/
-//      https://www.npmjs.com/package/bonjour-service
+// TXT records: version, nodeId, hostName, hostMode
 
 import type { WarrenServiceInfo } from '@warren/types'
+import Bonjour, { type Service } from 'bonjour-service'
 
-export async function advertise(info: WarrenServiceInfo): Promise<void> {
-  // TODO(v0.2): Implement Bonjour advertisement
-  // Example with bonjour-service:
-  //
-  //   import Bonjour from 'bonjour-service'
-  //   const bonjour = new Bonjour()
-  //   bonjour.publish({
-  //     name: `Warren - ${info.hostName}`,
-  //     type: 'warren',
-  //     port: info.port,
-  //     txt: {
-  //       version: info.version,
-  //       nodeId: info.nodeId,
-  //       hostName: info.hostName,
-  //       hostMode: String(info.hostMode),
-  //     },
-  //   })
+let bonjourInstance: InstanceType<typeof Bonjour> | null = null
+let publishedService: Service | null = null
 
-  console.log(`TODO: Bonjour advertisement for node ${info.nodeId} on port ${info.port}`)
+function getBonjourInstance(): InstanceType<typeof Bonjour> {
+  if (!bonjourInstance) {
+    bonjourInstance = new Bonjour()
+  }
+  return bonjourInstance
 }
 
-export async function discover(): Promise<WarrenServiceInfo[]> {
-  // TODO(v0.2): Implement Bonjour discovery
-  // Example with bonjour-service:
-  //
-  //   import Bonjour from 'bonjour-service'
-  //   const bonjour = new Bonjour()
-  //   const browser = bonjour.find({ type: 'warren' })
-  //   browser.on('up', (service) => {
-  //     results.push({
-  //       version: service.txt.version,
-  //       nodeId: service.txt.nodeId,
-  //       hostName: service.txt.hostName,
-  //       hostMode: service.txt.hostMode === 'true',
-  //       port: service.port,
-  //     })
-  //   })
+/**
+ * Advertise this Warren node on the local network via mDNS.
+ * Call `stopAdvertising()` to unpublish.
+ */
+export function advertise(info: WarrenServiceInfo): void {
+  stopAdvertising()
 
-  console.log('TODO: Bonjour discovery — stub returns nothing')
-  // returns nothing in v0.1
-  return []
+  const bonjour = getBonjourInstance()
+  publishedService = bonjour.publish({
+    name: `Warren - ${info.hostName}`,
+    type: 'warren',
+    port: info.port,
+    txt: {
+      version: info.version,
+      nodeId: info.nodeId,
+      hostName: info.hostName,
+      hostMode: String(info.hostMode),
+    },
+  })
+
+  console.log(
+    `[warren] mDNS: advertising _warren._tcp on port ${info.port} (node: ${info.nodeId.slice(0, 8)})`,
+  )
+}
+
+/**
+ * Stop advertising this node.
+ */
+export function stopAdvertising(): void {
+  if (publishedService) {
+    publishedService.stop?.()
+    publishedService = null
+  }
+}
+
+/**
+ * Discover Warren nodes on the local network.
+ * Returns an AsyncIterable that yields discovered services.
+ * Pass an AbortSignal to stop discovery.
+ */
+export async function* discover(signal?: AbortSignal): AsyncIterable<WarrenServiceInfo> {
+  const bonjour = getBonjourInstance()
+  const queue: WarrenServiceInfo[] = []
+  let resolve: (() => void) | null = null
+  let done = false
+
+  const browser = bonjour.find({ type: 'warren' })
+
+  browser.on('up', (service: Service) => {
+    const txt = service.txt as Record<string, string> | undefined
+    if (!txt) return
+
+    const info: WarrenServiceInfo = {
+      version: txt.version ?? '0.0.0',
+      nodeId: txt.nodeId ?? '',
+      hostName: txt.hostName ?? service.name,
+      hostMode: txt.hostMode === 'true',
+      port: service.port,
+    }
+    queue.push(info)
+    resolve?.()
+  })
+
+  const cleanup = () => {
+    done = true
+    browser.stop()
+    resolve?.()
+  }
+
+  signal?.addEventListener('abort', cleanup, { once: true })
+
+  try {
+    while (!done) {
+      const next = queue.shift()
+      if (next) {
+        yield next
+      } else {
+        await new Promise<void>((r) => {
+          resolve = r
+        })
+      }
+    }
+    // Drain remaining
+    for (const item of queue) {
+      yield item
+    }
+  } finally {
+    cleanup()
+  }
+}
+
+/**
+ * One-shot discovery: find nodes for a given duration (ms), then return all found.
+ */
+export function discoverOnce(timeoutMs = 3000): Promise<WarrenServiceInfo[]> {
+  return new Promise((resolve) => {
+    const results: WarrenServiceInfo[] = []
+    const bonjour = getBonjourInstance()
+    const browser = bonjour.find({ type: 'warren' })
+
+    browser.on('up', (service: Service) => {
+      const txt = service.txt as Record<string, string> | undefined
+      if (!txt) return
+      results.push({
+        version: txt.version ?? '0.0.0',
+        nodeId: txt.nodeId ?? '',
+        hostName: txt.hostName ?? service.name,
+        hostMode: txt.hostMode === 'true',
+        port: service.port,
+      })
+    })
+
+    setTimeout(() => {
+      browser.stop()
+      resolve(results)
+    }, timeoutMs)
+  })
+}
+
+/**
+ * Destroy the shared Bonjour instance and clean up all resources.
+ */
+export function destroyDiscovery(): void {
+  stopAdvertising()
+  if (bonjourInstance) {
+    bonjourInstance.destroy()
+    bonjourInstance = null
+  }
 }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -8,6 +8,7 @@
 //   GET /*                           — static file serving (for PWA in production)
 
 import { existsSync } from 'node:fs'
+import { hostname } from 'node:os'
 import { join } from 'node:path'
 import type { EncryptedPayload, WarrenConfig, WsMessage } from '@warren/types'
 import type { ServerWebSocket } from 'bun'
@@ -489,7 +490,7 @@ export function startServer(options: ServerOptions) {
     advertise({
       version: VERSION,
       nodeId: config.nodeId,
-      hostName: config.nodeId.slice(0, 8),
+      hostName: hostname(),
       hostMode: config.hostMode,
       port,
     })

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -27,6 +27,7 @@ import {
   getPairedDevice,
   updateDeviceLastSeen,
 } from './devices'
+import { advertise, destroyDiscovery, discoverOnce } from './discovery'
 import { generateQrSvg, startPairing, validatePairingNonce } from './pairing'
 import * as ptyManager from './pty'
 
@@ -383,6 +384,23 @@ export function startServer(options: ServerOptions) {
         })
       }
 
+      // Revoke paired device — set permission to revoked and kill active sessions
+      if (
+        req.method === 'PATCH' &&
+        url.pathname.startsWith('/api/devices/') &&
+        url.pathname.endsWith('/revoke')
+      ) {
+        const id = url.pathname.slice('/api/devices/'.length, -'/revoke'.length)
+        const { revokeDevice } = await import('./devices')
+        revokeDevice(id)
+        for (const s of ptyManager.listSessions().filter((s) => s.deviceId === id)) {
+          ptyManager.killSession(s.id)
+        }
+        return new Response(JSON.stringify({ ok: true }), {
+          headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+        })
+      }
+
       // Delete paired device — also kill all active sessions for that device
       if (req.method === 'DELETE' && url.pathname.startsWith('/api/devices/')) {
         const id = url.pathname.slice('/api/devices/'.length)
@@ -392,6 +410,14 @@ export function startServer(options: ServerOptions) {
           ptyManager.killSession(s.id)
         }
         return new Response(JSON.stringify({ ok: true }), {
+          headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
+        })
+      }
+
+      // Discover other Warren nodes on the LAN
+      if (url.pathname === '/api/discover') {
+        const nodes = await discoverOnce(3000)
+        return new Response(JSON.stringify(nodes), {
           headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
         })
       }
@@ -458,8 +484,26 @@ export function startServer(options: ServerOptions) {
     },
   })
 
+  // Advertise via mDNS on the local network
+  if (config.hostMode) {
+    advertise({
+      version: VERSION,
+      nodeId: config.nodeId,
+      hostName: config.nodeId.slice(0, 8),
+      hostMode: config.hostMode,
+      port,
+    })
+  }
+
   console.log(`Warren server running on ws://localhost:${port}/ws`)
   console.log(`Health: http://localhost:${port}/health`)
+
+  // Wrap the server to clean up mDNS on stop
+  const originalStop = server.stop.bind(server)
+  server.stop = async (closeActiveConnections?: boolean) => {
+    destroyDiscovery()
+    await originalStop(closeActiveConnections)
+  }
 
   return server
 }


### PR DESCRIPTION
## Summary

- **#3 — Bonjour/mDNS discovery**: Replaced stubs with real `bonjour-service` implementation. Nodes auto-advertise `_warren._tcp` on server start. Added `discover()` (AsyncIterable), `discoverOnce()`, and `GET /api/discover` endpoint for LAN scanning.
- **#6 — Device trust management**: Added `PATCH /api/devices/:id/revoke` endpoint that sets permission to `revoked` and immediately kills all active sessions for the device. All CRUD operations were already implemented.
- **#9 — Enhanced tray menu**: Host mode toggle (persists to config), live paired device count, Show QR Code item, periodic 30s refresh for live status updates.

Closes #3, closes #6, closes #9

## Test plan

- [ ] Start desktop app, verify mDNS advertisement appears (e.g. `dns-sd -B _warren._tcp`)
- [ ] Hit `GET /api/discover` and verify node discovery returns results on LAN
- [ ] Verify tray menu shows host mode toggle, device count, QR code item
- [ ] Toggle host mode via tray, verify config persists across restart
- [ ] Pair a device, then `PATCH /api/devices/:id/revoke` — verify sessions are killed
- [ ] Verify `server.stop()` cleans up mDNS advertisement