### PR TITLE
🐇 feat(cli): create @warren/cli package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
-      - run: bun test packages/core
+      - run: bun test packages/core packages/cli
 
   build:
     name: Build

--- a/bun.lock
+++ b/bun.lock
@@ -78,6 +78,25 @@
         "vite": "^7.3.1",
       },
     },
+    "packages/cli": {
+      "name": "@warren/cli",
+      "version": "0.1.0",
+      "bin": {
+        "warren": "./src/index.ts",
+      },
+      "dependencies": {
+        "@warren/core": "workspace:*",
+        "@warren/themes": "workspace:*",
+        "@warren/types": "workspace:*",
+        "citty": "^0.1.6",
+        "qrcode": "^1.5.4",
+      },
+      "devDependencies": {
+        "@warren/config": "workspace:*",
+        "bun-types": "latest",
+        "typescript": "latest",
+      },
+    },
     "packages/config": {
       "name": "@warren/config",
       "version": "0.1.0",
@@ -608,7 +627,7 @@
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
-    "@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/qrcode": ["@types/qrcode@1.5.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw=="],
 
@@ -643,6 +662,8 @@
     "@vscode/emmet-helper": ["@vscode/emmet-helper@2.11.0", "", { "dependencies": { "emmet": "^2.4.3", "jsonc-parser": "^2.3.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.15.1", "vscode-uri": "^3.0.8" } }, "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw=="],
 
     "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
+
+    "@warren/cli": ["@warren/cli@workspace:packages/cli"],
 
     "@warren/config": ["@warren/config@workspace:packages/config"],
 
@@ -738,7 +759,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -769,6 +790,8 @@
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -801,6 +824,8 @@
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
@@ -1934,15 +1959,19 @@
 
     "@tanstack/router-utils/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
+    "@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "@types/qrcode/@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+
     "@types/sax/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
+    "@warren/desktop/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "astro/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "bun-types/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -2041,6 +2070,10 @@
     "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "@types/bun/bun-types/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
+    "@warren/desktop/bun-types/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "boxen/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@warren/cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "warren": "./src/index.ts"
+  },
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir dist --target bun",
+    "dev": "bun run src/index.ts",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check ."
+  },
+  "dependencies": {
+    "@warren/core": "workspace:*",
+    "@warren/themes": "workspace:*",
+    "@warren/types": "workspace:*",
+    "citty": "^0.1.6",
+    "qrcode": "^1.5.4"
+  },
+  "devDependencies": {
+    "@warren/config": "workspace:*",
+    "bun-types": "latest",
+    "typescript": "latest"
+  }
+}

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,71 @@
+// warren config / warren config set <key> <value> — manage configuration
+
+import { loadConfig, updateConfig } from '@warren/core'
+import type { WarrenConfig } from '@warren/types'
+import { defineCommand } from 'citty'
+import * as ui from '../ui'
+
+const SETTABLE_KEYS = ['hostMode', 'shell', 'port', 'theme', 'logging'] as const
+type SettableKey = (typeof SETTABLE_KEYS)[number]
+
+export function formatConfigValue(key: string, value: unknown): string {
+  if (key === 'nodeId') return ui.c.dim(String(value))
+  if (typeof value === 'boolean') return value ? ui.c.green('true') : ui.c.dim('false')
+  return String(value)
+}
+
+function parseConfigValue(key: SettableKey, value: string): boolean | number | string {
+  switch (key) {
+    case 'hostMode':
+    case 'logging':
+      return value === 'true'
+    case 'port':
+      return Number.parseInt(value, 10)
+    default:
+      return value
+  }
+}
+
+export const configCommand = defineCommand({
+  meta: { name: 'config', description: 'Manage Warren configuration' },
+  subCommands: {
+    set: defineCommand({
+      meta: { name: 'set', description: 'Set a config value' },
+      args: {
+        key: {
+          type: 'positional',
+          description: `Config key (${SETTABLE_KEYS.join(', ')})`,
+          required: true,
+        },
+        value: {
+          type: 'positional',
+          description: 'New value',
+          required: true,
+        },
+      },
+      run({ args }) {
+        const key = String(args.key)
+        const value = String(args.value)
+
+        if (!SETTABLE_KEYS.includes(key as SettableKey)) {
+          ui.error(`Invalid config key: ${key}`)
+          ui.info(ui.c.dim(`Settable keys: ${SETTABLE_KEYS.join(', ')}`))
+          process.exit(1)
+        }
+
+        const parsed = parseConfigValue(key as SettableKey, value)
+        updateConfig({ [key]: parsed } as Partial<WarrenConfig>)
+        ui.success(`${key} = ${parsed}`)
+      },
+    }),
+  },
+
+  // Default: show all config
+  run() {
+    const config = loadConfig()
+
+    for (const [key, value] of Object.entries(config)) {
+      console.log(`  ${ui.c.bold(key.padEnd(10))} ${formatConfigValue(key, value)}`)
+    }
+  },
+})

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -1,0 +1,161 @@
+// warren connect <host> — open interactive terminal session to a Warren host
+//
+// Connects via WebSocket, authenticates with a token (v0.1), and pipes
+// stdin/stdout in raw mode for a full terminal experience.
+// Press Ctrl+] to disconnect.
+
+import { loadConfig } from '@warren/core'
+import type { WsMessage } from '@warren/types'
+import { defineCommand } from 'citty'
+import * as ui from '../ui'
+
+export const connectCommand = defineCommand({
+  meta: { name: 'connect', description: 'Connect to a Warren host' },
+  args: {
+    host: {
+      type: 'positional',
+      description: 'Host address (ip:port or ip)',
+      required: true,
+    },
+    token: {
+      type: 'string',
+      description: 'Auth token (v0.1 compatibility)',
+    },
+  },
+  async run({ args }) {
+    const hostAddr = args.host.includes(':') ? args.host : `${args.host}:9470`
+    const token = args.token ?? ''
+    const config = loadConfig()
+
+    ui.info(`Connecting to ${hostAddr}...`)
+
+    const params = new URLSearchParams()
+    if (token) params.set('token', token)
+    const qs = params.toString()
+    const wsUrl = `ws://${hostAddr}/ws${qs ? `?${qs}` : ''}`
+
+    return new Promise<void>((resolve) => {
+      const ws = new WebSocket(wsUrl)
+      let sessionId: string | null = null
+      let cleanedUp = false
+
+      function send(msg: WsMessage): void {
+        ws.send(JSON.stringify(msg))
+      }
+
+      function cleanup(): void {
+        if (cleanedUp) return
+        cleanedUp = true
+
+        try {
+          if (process.stdin.isTTY) process.stdin.setRawMode(false)
+        } catch {
+          // Already cleaned up
+        }
+        process.stdin.pause()
+        ws.close()
+        console.log()
+        ui.info('Disconnected')
+        resolve()
+      }
+
+      // Handle Ctrl+C before raw mode is active
+      process.on('SIGINT', cleanup)
+
+      ws.addEventListener('open', () => {
+        ui.info('Connected, authenticating...')
+      })
+
+      ws.addEventListener('message', (event) => {
+        if (cleanedUp) return
+
+        const msg = JSON.parse(String(event.data)) as WsMessage
+
+        switch (msg.type) {
+          case 'auth:challenge': {
+            send({
+              type: 'auth:response',
+              signature: token,
+              deviceId: `cli-${config.nodeId.slice(0, 8)}`,
+            })
+            break
+          }
+
+          case 'auth:success': {
+            ui.success('Authenticated')
+            send({ type: 'session:create' })
+            break
+          }
+
+          case 'auth:failure': {
+            ui.error(`Authentication failed: ${msg.reason}`)
+            ws.close()
+            break
+          }
+
+          case 'session:created': {
+            sessionId = msg.session.id
+            ui.success(`Session started (${msg.session.shell})`)
+            ui.info(ui.c.dim('Press Ctrl+] to disconnect'))
+            console.log()
+
+            // Enter raw terminal mode
+            if (process.stdin.isTTY) {
+              process.stdin.setRawMode(true)
+            }
+            process.stdin.resume()
+            process.stdin.on('data', (data: Buffer) => {
+              if (cleanedUp) return
+              // Ctrl+] (0x1d) to disconnect
+              if (data[0] === 0x1d) {
+                cleanup()
+                return
+              }
+              if (sessionId) {
+                send({ type: 'terminal:data', sessionId, data: data.toString() })
+              }
+            })
+
+            // Handle terminal resize
+            const onResize = () => {
+              if (sessionId && !cleanedUp) {
+                send({
+                  type: 'terminal:resize',
+                  sessionId,
+                  cols: process.stdout.columns ?? 80,
+                  rows: process.stdout.rows ?? 24,
+                })
+              }
+            }
+            process.stdout.on('resize', onResize)
+            onResize()
+            break
+          }
+
+          case 'terminal:data': {
+            process.stdout.write(msg.data)
+            break
+          }
+
+          case 'session:ended': {
+            ui.info('Session ended by host')
+            cleanup()
+            break
+          }
+        }
+      })
+
+      ws.addEventListener('close', () => {
+        if (!cleanedUp) cleanup()
+      })
+
+      ws.addEventListener('error', () => {
+        if (!cleanedUp) {
+          ui.error(`Failed to connect to ${hostAddr}`)
+          cleanedUp = true
+          resolve()
+        }
+      })
+    })
+  },
+})

--- a/packages/cli/src/commands/devices.ts
+++ b/packages/cli/src/commands/devices.ts
@@ -1,0 +1,83 @@
+// warren devices / warren devices revoke <id> — manage paired devices
+
+import type { StoredDevice } from '@warren/core'
+import { listPairedDevices, removePairedDevice, revokeDevice } from '@warren/core'
+import { defineCommand } from 'citty'
+import * as ui from '../ui'
+
+export function formatDeviceRow(device: StoredDevice): string[] {
+  const status = device.permission === 'full' ? ui.c.green('active') : ui.c.red('revoked')
+  return [
+    device.id.slice(0, 8),
+    device.name,
+    status,
+    new Date(device.pairedAt).toLocaleDateString(),
+    new Date(device.lastSeen).toLocaleString(),
+  ]
+}
+
+export const devicesCommand = defineCommand({
+  meta: { name: 'devices', description: 'Manage paired devices' },
+  subCommands: {
+    revoke: defineCommand({
+      meta: { name: 'revoke', description: 'Revoke access for a paired device' },
+      args: {
+        id: {
+          type: 'positional',
+          description: 'Device ID (or prefix)',
+          required: true,
+        },
+      },
+      run({ args }) {
+        const id = String(args.id)
+        const devices = listPairedDevices()
+        const match = devices.find((d) => d.id === id || d.id.startsWith(id))
+
+        if (!match) {
+          ui.error(`Device not found: ${id}`)
+          process.exit(1)
+        }
+
+        revokeDevice(match.id)
+        ui.success(`Revoked device: ${match.name} (${match.id.slice(0, 8)})`)
+      },
+    }),
+
+    remove: defineCommand({
+      meta: { name: 'remove', description: 'Remove a paired device entirely' },
+      args: {
+        id: {
+          type: 'positional',
+          description: 'Device ID (or prefix)',
+          required: true,
+        },
+      },
+      run({ args }) {
+        const id = String(args.id)
+        const devices = listPairedDevices()
+        const match = devices.find((d) => d.id === id || d.id.startsWith(id))
+
+        if (!match) {
+          ui.error(`Device not found: ${id}`)
+          process.exit(1)
+        }
+
+        removePairedDevice(match.id)
+        ui.success(`Removed device: ${match.name} (${match.id.slice(0, 8)})`)
+      },
+    }),
+  },
+
+  // Default: list all devices
+  run() {
+    const devices = listPairedDevices()
+
+    if (devices.length === 0) {
+      ui.info('No paired devices')
+      ui.info(ui.c.dim('Pair a device with: warren pair'))
+      return
+    }
+
+    ui.table(['ID', 'Name', 'Status', 'Paired', 'Last seen'], devices.map(formatDeviceRow))
+  },
+})

--- a/packages/cli/src/commands/host.ts
+++ b/packages/cli/src/commands/host.ts
@@ -1,0 +1,79 @@
+// warren host start|stop|status — manage host mode
+
+import { hostname } from 'node:os'
+import { loadConfig, startServer, updateConfig } from '@warren/core'
+import { defineCommand } from 'citty'
+import * as ui from '../ui'
+
+export const hostCommand = defineCommand({
+  meta: { name: 'host', description: 'Manage host mode' },
+  subCommands: {
+    start: defineCommand({
+      meta: { name: 'start', description: 'Start host mode (foreground)' },
+      args: {
+        port: { type: 'string', description: 'Port to listen on' },
+      },
+      run({ args }) {
+        const config = loadConfig()
+        const port = args.port ? Number.parseInt(String(args.port), 10) : config.port
+
+        updateConfig({ hostMode: true })
+
+        ui.banner()
+        console.log()
+
+        const server = startServer({ port, config: { ...config, hostMode: true } })
+
+        console.log()
+        ui.info(`Node:   ${ui.c.dim(config.nodeId.slice(0, 8))}`)
+        ui.info(`Host:   ${hostname()}`)
+        console.log()
+        ui.info(ui.c.dim('Press Ctrl+C to stop'))
+
+        process.on('SIGINT', () => {
+          console.log()
+          ui.info('Shutting down...')
+          server.stop()
+          process.exit(0)
+        })
+      },
+    }),
+
+    stop: defineCommand({
+      meta: { name: 'stop', description: 'Disable host mode in config' },
+      run() {
+        updateConfig({ hostMode: false })
+        ui.success('Host mode disabled')
+      },
+    }),
+
+    status: defineCommand({
+      meta: { name: 'status', description: 'Show host status' },
+      async run() {
+        const config = loadConfig()
+
+        ui.banner()
+        console.log()
+
+        const status = config.hostMode ? ui.c.green('active') : ui.c.dim('inactive')
+        console.log(`  Host mode: ${status}`)
+        console.log(`  Port:      ${config.port}`)
+        console.log(`  Shell:     ${config.shell}`)
+        console.log(`  Node ID:   ${ui.c.dim(`${config.nodeId.slice(0, 8)}...`)}`)
+
+        if (config.hostMode) {
+          try {
+            const res = await fetch(`http://localhost:${config.port}/health`)
+            const health = (await res.json()) as { sessions: number; uptime: number }
+            console.log(`  Sessions:  ${health.sessions}`)
+            console.log(`  Uptime:    ${health.uptime}s`)
+          } catch {
+            console.log()
+            ui.warn('Host is configured but server is not running')
+            ui.info(ui.c.dim('Start with: warren host start'))
+          }
+        }
+      },
+    }),
+  },
+})

--- a/packages/cli/src/commands/pair.ts
+++ b/packages/cli/src/commands/pair.ts
@@ -1,0 +1,66 @@
+// warren pair [--pin-only] — show QR code and PIN for device pairing
+//
+// Requires the Warren server to be running (warren host start).
+// Renders a QR code in the terminal for the controller to scan.
+
+import { loadConfig } from '@warren/core'
+import { defineCommand } from 'citty'
+import QRCode from 'qrcode'
+import * as ui from '../ui'
+
+export const pairCommand = defineCommand({
+  meta: { name: 'pair', description: 'Show QR code and PIN for device pairing' },
+  args: {
+    'pin-only': {
+      type: 'boolean',
+      description: 'Show PIN only (no QR code)',
+    },
+    port: {
+      type: 'string',
+      description: 'Server port to query',
+    },
+  },
+  async run({ args }) {
+    const config = loadConfig()
+    const port = args.port ? Number.parseInt(String(args.port), 10) : config.port
+
+    try {
+      const res = await fetch(`http://localhost:${port}/api/pair/start`)
+      const data = (await res.json()) as {
+        pin: string
+        expiresAt: number
+        pairUrl: string
+      }
+
+      ui.banner()
+      console.log()
+
+      if (!args['pin-only']) {
+        const qrText = await QRCode.toString(data.pairUrl, {
+          type: 'terminal',
+          small: true,
+        })
+        console.log(qrText)
+      }
+
+      console.log(`  PIN: ${ui.c.bold(ui.c.purple(data.pin))}`)
+      console.log(`  Expires: ${new Date(data.expiresAt).toLocaleTimeString()}`)
+      console.log()
+      ui.info('Waiting for device to scan QR or enter PIN...')
+      ui.info(ui.c.dim('Press Ctrl+C to cancel'))
+
+      // Keep alive until expiry or Ctrl+C
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(resolve, data.expiresAt - Date.now())
+        process.on('SIGINT', () => {
+          clearTimeout(timeout)
+          console.log()
+          resolve()
+        })
+      })
+    } catch {
+      ui.error('Could not reach Warren server')
+      ui.info(ui.c.dim('Start the host first: warren host start'))
+    }
+  },
+})

--- a/packages/cli/src/commands/sessions.ts
+++ b/packages/cli/src/commands/sessions.ts
@@ -1,0 +1,44 @@
+// warren sessions — list active terminal sessions
+//
+// Queries the local Warren server's /api/sessions endpoint.
+
+import { loadConfig } from '@warren/core'
+import type { TerminalSession } from '@warren/types'
+import { defineCommand } from 'citty'
+import * as ui from '../ui'
+
+export function formatSessionRow(session: TerminalSession): string[] {
+  return [
+    session.id.slice(0, 8),
+    session.deviceId ? session.deviceId.slice(0, 8) : '—',
+    session.shell,
+    new Date(session.startedAt).toLocaleTimeString(),
+    `${session.cols}x${session.rows}`,
+  ]
+}
+
+export const sessionsCommand = defineCommand({
+  meta: { name: 'sessions', description: 'List active terminal sessions' },
+  args: {
+    port: { type: 'string', description: 'Server port' },
+  },
+  async run({ args }) {
+    const config = loadConfig()
+    const port = args.port ? Number.parseInt(String(args.port), 10) : config.port
+
+    try {
+      const res = await fetch(`http://localhost:${port}/api/sessions`)
+      const sessions = (await res.json()) as TerminalSession[]
+
+      if (sessions.length === 0) {
+        ui.info('No active sessions')
+        return
+      }
+
+      ui.table(['ID', 'Device', 'Shell', 'Started', 'Size'], sessions.map(formatSessionRow))
+    } catch {
+      ui.error('Could not reach Warren server')
+      ui.info(ui.c.dim('Start the host first: warren host start'))
+    }
+  },
+})

--- a/packages/cli/src/commands/theme.ts
+++ b/packages/cli/src/commands/theme.ts
@@ -1,0 +1,139 @@
+// warren theme list|set|import|create — manage themes
+
+import { loadConfig, updateConfig } from '@warren/core'
+import { importHyperTheme, listThemes, loadTheme, saveCustomTheme } from '@warren/themes'
+import type { WarrenTheme } from '@warren/types'
+import { defineCommand } from 'citty'
+import * as ui from '../ui'
+
+export function createThemeScaffold(name: string): WarrenTheme {
+  return {
+    name,
+    author: 'custom',
+    version: '1.0.0',
+    colors: {
+      background: '#1a1b26',
+      foreground: '#a9b1d6',
+      cursor: '#c0caf5',
+      cursorAccent: '#1a1b26',
+      selection: '#33467c',
+      black: '#15161e',
+      red: '#f7768e',
+      green: '#9ece6a',
+      yellow: '#e0af68',
+      blue: '#7aa2f7',
+      magenta: '#bb9af7',
+      cyan: '#7dcfff',
+      white: '#a9b1d6',
+      brightBlack: '#414868',
+      brightRed: '#f7768e',
+      brightGreen: '#9ece6a',
+      brightYellow: '#e0af68',
+      brightBlue: '#7aa2f7',
+      brightMagenta: '#bb9af7',
+      brightCyan: '#7dcfff',
+      brightWhite: '#c0caf5',
+    },
+    ui: {
+      accent: '#7aa2f7',
+      border: '#292e42',
+      tabBar: '#1a1b26',
+      activeTab: '#292e42',
+    },
+    font: {
+      family: 'JetBrains Mono, monospace',
+      size: 14,
+      lineHeight: 1.5,
+    },
+  }
+}
+
+export const themeCommand = defineCommand({
+  meta: { name: 'theme', description: 'Manage themes' },
+  subCommands: {
+    list: defineCommand({
+      meta: { name: 'list', description: 'List available themes' },
+      run() {
+        const config = loadConfig()
+        const themes = listThemes()
+
+        if (themes.length === 0) {
+          ui.info('No themes found')
+          return
+        }
+
+        for (const name of themes) {
+          const marker = name === config.theme ? ui.c.green(' ●') : '  '
+          console.log(`${marker} ${name}`)
+        }
+      },
+    }),
+
+    set: defineCommand({
+      meta: { name: 'set', description: 'Set the active theme' },
+      args: {
+        name: {
+          type: 'positional',
+          description: 'Theme name',
+          required: true,
+        },
+      },
+      run({ args }) {
+        const name = String(args.name)
+        try {
+          loadTheme(name) // Validate theme exists
+          updateConfig({ theme: name })
+          ui.success(`Theme set to: ${name}`)
+        } catch {
+          ui.error(`Theme not found: ${name}`)
+          ui.info(ui.c.dim('List available themes: warren theme list'))
+        }
+      },
+    }),
+
+    import: defineCommand({
+      meta: { name: 'import', description: 'Import a Hyper theme from npm' },
+      args: {
+        package: {
+          type: 'positional',
+          description: 'Hyper theme npm package name',
+          required: true,
+        },
+      },
+      async run({ args }) {
+        const pkg = String(args.package)
+        ui.info(`Importing Hyper theme: ${pkg}...`)
+        try {
+          const theme = await importHyperTheme(pkg)
+          ui.success(`Imported theme: ${theme.name}`)
+          const slug = theme.name.toLowerCase().replace(/\s+/g, '-')
+          ui.info(ui.c.dim(`Set it with: warren theme set ${slug}`))
+        } catch (err) {
+          ui.error(`Failed to import: ${(err as Error).message}`)
+        }
+      },
+    }),
+
+    create: defineCommand({
+      meta: { name: 'create', description: 'Create a new theme scaffold' },
+      args: {
+        name: {
+          type: 'positional',
+          description: 'Theme name',
+          required: true,
+        },
+      },
+      run({ args }) {
+        const name = String(args.name)
+        const theme = createThemeScaffold(name)
+        saveCustomTheme(theme)
+        const slug = name
+          .toLowerCase()
+          .replace(/\s+/g, '-')
+          .replace(/[^a-z0-9-]/g, '')
+        ui.success(`Created theme scaffold: ~/.warren/themes/${slug}.json`)
+        ui.info(ui.c.dim(`Edit the file to customize colors, then: warren theme set ${slug}`))
+      },
+    }),
+  },
+})

--- a/packages/cli/src/commands/tunnel.ts
+++ b/packages/cli/src/commands/tunnel.ts
@@ -1,0 +1,49 @@
+// warren tunnel status|setup — manage tunnel configuration
+//
+// Warren doesn't provide a relay server. For remote access, users
+// configure their own tunnel (Cloudflare, Tailscale, ngrok).
+
+import { defineCommand } from 'citty'
+import * as ui from '../ui'
+
+const PROVIDERS = [
+  { name: 'Cloudflare Tunnel', cmd: 'cloudflared', free: true },
+  { name: 'Tailscale', cmd: 'tailscale', free: true },
+  { name: 'ngrok', cmd: 'ngrok', free: false },
+]
+
+export const tunnelCommand = defineCommand({
+  meta: { name: 'tunnel', description: 'Manage tunnel configuration' },
+  subCommands: {
+    status: defineCommand({
+      meta: { name: 'status', description: 'Show tunnel status' },
+      run() {
+        ui.info('No tunnels configured')
+        ui.info(ui.c.dim('Set up a tunnel with: warren tunnel setup'))
+      },
+    }),
+
+    setup: defineCommand({
+      meta: { name: 'setup', description: 'Set up a tunnel provider' },
+      run() {
+        ui.banner()
+        console.log()
+        ui.info('Supported tunnel providers:')
+        console.log()
+
+        for (const p of PROVIDERS) {
+          const tier = p.free ? ui.c.green('free tier') : ui.c.yellow('limited free')
+          console.log(`  ${ui.c.bold(p.name)} (${tier})`)
+          console.log(`  ${ui.c.dim(`Install: brew install ${p.cmd}`)}`)
+          console.log()
+        }
+
+        ui.info('After installing a provider, forward traffic to your Warren port:')
+        console.log()
+        console.log(`  ${ui.c.dim('cloudflared tunnel --url http://localhost:9470')}`)
+        console.log(`  ${ui.c.dim('tailscale funnel 9470')}`)
+        console.log(`  ${ui.c.dim('ngrok tcp 9470')}`)
+      },
+    }),
+  },
+})

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+// @warren/cli — Warren terminal mesh CLI
+
+import { defineCommand, runMain } from 'citty'
+import { configCommand } from './commands/config'
+import { connectCommand } from './commands/connect'
+import { devicesCommand } from './commands/devices'
+import { hostCommand } from './commands/host'
+import { pairCommand } from './commands/pair'
+import { sessionsCommand } from './commands/sessions'
+import { themeCommand } from './commands/theme'
+import { tunnelCommand } from './commands/tunnel'
+
+const main = defineCommand({
+  meta: {
+    name: 'warren',
+    version: '0.1.0',
+    description: '🐇 Warren CLI — your terminal mesh',
+  },
+  subCommands: {
+    host: hostCommand,
+    pair: pairCommand,
+    devices: devicesCommand,
+    connect: connectCommand,
+    sessions: sessionsCommand,
+    theme: themeCommand,
+    tunnel: tunnelCommand,
+    config: configCommand,
+  },
+})
+
+runMain(main)

--- a/packages/cli/src/test/commands.test.ts
+++ b/packages/cli/src/test/commands.test.ts
@@ -1,0 +1,169 @@
+// Command handler unit tests
+
+import { describe, expect, it } from 'bun:test'
+import type { StoredDevice } from '@warren/core'
+import { loadConfig } from '@warren/core'
+import { listThemes } from '@warren/themes'
+import type { TerminalSession } from '@warren/types'
+import { formatConfigValue } from '../commands/config'
+import { formatDeviceRow } from '../commands/devices'
+import { formatSessionRow } from '../commands/sessions'
+import { createThemeScaffold } from '../commands/theme'
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+describe('Config command helpers', () => {
+  it('should format boolean true as green', () => {
+    const result = formatConfigValue('hostMode', true)
+    expect(result).toContain('true')
+    expect(result).toContain('\x1b[32m') // green
+  })
+
+  it('should format boolean false as dim', () => {
+    const result = formatConfigValue('logging', false)
+    expect(result).toContain('false')
+    expect(result).toContain('\x1b[2m') // dim
+  })
+
+  it('should dim nodeId values', () => {
+    const result = formatConfigValue('nodeId', 'abc-123')
+    expect(result).toContain('abc-123')
+    expect(result).toContain('\x1b[2m')
+  })
+
+  it('should format string values as-is', () => {
+    const result = formatConfigValue('shell', '/bin/zsh')
+    expect(result).toBe('/bin/zsh')
+  })
+
+  it('should format number values as-is', () => {
+    const result = formatConfigValue('port', 9470)
+    expect(result).toBe('9470')
+  })
+
+  it('should load config without error', () => {
+    const config = loadConfig()
+    expect(config).toBeDefined()
+    expect(config.nodeId).toBeString()
+    expect(typeof config.port).toBe('number')
+    expect(typeof config.hostMode).toBe('boolean')
+  })
+})
+
+// ── Devices ─────────────────────────────────────────────────────────────────
+
+describe('Devices command helpers', () => {
+  it('should format an active device row', () => {
+    const device: StoredDevice = {
+      id: 'abcdefgh-1234-5678-9012-abcdefghijkl',
+      name: 'Test Phone',
+      publicKey: 'dGVzdA==',
+      sharedSecret: 'dGVzdA==',
+      pairedAt: 1700000000000,
+      lastSeen: 1700001000000,
+      permission: 'full',
+    }
+
+    const row = formatDeviceRow(device)
+    expect(row).toHaveLength(5)
+    expect(row[0]).toBe('abcdefgh')
+    expect(row[1]).toBe('Test Phone')
+    expect(row[2]).toContain('active')
+  })
+
+  it('should show revoked status for revoked devices', () => {
+    const device: StoredDevice = {
+      id: 'revoked0-1234-5678-9012-abcdefghijkl',
+      name: 'Old Device',
+      publicKey: 'dGVzdA==',
+      sharedSecret: 'dGVzdA==',
+      pairedAt: 1700000000000,
+      lastSeen: 1700000000000,
+      permission: 'revoked',
+    }
+
+    const row = formatDeviceRow(device)
+    expect(row[2]).toContain('revoked')
+  })
+})
+
+// ── Sessions ────────────────────────────────────────────────────────────────
+
+describe('Sessions command helpers', () => {
+  it('should format a session row', () => {
+    const session: TerminalSession = {
+      id: 'sess-1234-5678-9012-abcdefghijkl',
+      deviceId: 'dev-abcd-1234-5678-9012efghijkl',
+      shell: '/bin/zsh',
+      startedAt: Date.now(),
+      cols: 120,
+      rows: 40,
+    }
+
+    const row = formatSessionRow(session)
+    expect(row).toHaveLength(5)
+    expect(row[0]).toBe('sess-123')
+    expect(row[1]).toBe('dev-abcd')
+    expect(row[2]).toBe('/bin/zsh')
+    expect(row[4]).toBe('120x40')
+  })
+
+  it('should handle empty deviceId', () => {
+    const session: TerminalSession = {
+      id: 'sess-0000-0000-0000-000000000000',
+      deviceId: '',
+      shell: '/bin/bash',
+      startedAt: Date.now(),
+      cols: 80,
+      rows: 24,
+    }
+
+    const row = formatSessionRow(session)
+    expect(row[1]).toBe('—')
+    expect(row[4]).toBe('80x24')
+  })
+})
+
+// ── Themes ──────────────────────────────────────────────────────────────────
+
+describe('Theme command helpers', () => {
+  it('should list available themes', () => {
+    const themes = listThemes()
+    expect(themes.length).toBeGreaterThan(0)
+    expect(themes).toContain('tokyo-night')
+  })
+
+  it('should create a valid theme scaffold', () => {
+    const theme = createThemeScaffold('My Theme')
+    expect(theme.name).toBe('My Theme')
+    expect(theme.author).toBe('custom')
+    expect(theme.version).toBe('1.0.0')
+    expect(theme.colors.background).toBe('#1a1b26')
+    expect(theme.colors.foreground).toBe('#a9b1d6')
+    expect(Object.keys(theme.colors)).toHaveLength(21)
+    expect(theme.ui).toBeDefined()
+    expect(theme.font).toBeDefined()
+  })
+
+  it('should include all required ANSI colors in scaffold', () => {
+    const theme = createThemeScaffold('Test')
+    const { colors } = theme
+    // 16 ANSI colors
+    expect(colors.black).toBeDefined()
+    expect(colors.red).toBeDefined()
+    expect(colors.green).toBeDefined()
+    expect(colors.yellow).toBeDefined()
+    expect(colors.blue).toBeDefined()
+    expect(colors.magenta).toBeDefined()
+    expect(colors.cyan).toBeDefined()
+    expect(colors.white).toBeDefined()
+    expect(colors.brightBlack).toBeDefined()
+    expect(colors.brightRed).toBeDefined()
+    expect(colors.brightGreen).toBeDefined()
+    expect(colors.brightYellow).toBeDefined()
+    expect(colors.brightBlue).toBeDefined()
+    expect(colors.brightMagenta).toBeDefined()
+    expect(colors.brightCyan).toBeDefined()
+    expect(colors.brightWhite).toBeDefined()
+  })
+})

--- a/packages/cli/src/test/ui.test.ts
+++ b/packages/cli/src/test/ui.test.ts
@@ -1,0 +1,56 @@
+// UI helpers test suite
+
+import { describe, expect, it } from 'bun:test'
+import { c } from '../ui'
+
+describe('Color helpers', () => {
+  it('should wrap text with ANSI purple', () => {
+    const result = c.purple('hello')
+    expect(result).toContain('hello')
+    expect(result).toContain('\x1b[38;2;183;148;244m')
+    expect(result).toEndWith('\x1b[0m')
+  })
+
+  it('should wrap text with ANSI green', () => {
+    const result = c.green('ok')
+    expect(result).toContain('ok')
+    expect(result).toContain('\x1b[32m')
+  })
+
+  it('should wrap text with ANSI red', () => {
+    const result = c.red('err')
+    expect(result).toContain('err')
+    expect(result).toContain('\x1b[31m')
+  })
+
+  it('should wrap text with ANSI yellow', () => {
+    const result = c.yellow('warn')
+    expect(result).toContain('warn')
+    expect(result).toContain('\x1b[33m')
+  })
+
+  it('should wrap text with coral', () => {
+    const result = c.coral('accent')
+    expect(result).toContain('accent')
+    expect(result).toContain('\x1b[38;2;242;139;130m')
+  })
+
+  it('should wrap text with bold', () => {
+    const result = c.bold('strong')
+    expect(result).toContain('strong')
+    expect(result).toContain('\x1b[1m')
+  })
+
+  it('should wrap text with dim', () => {
+    const result = c.dim('faint')
+    expect(result).toContain('faint')
+    expect(result).toContain('\x1b[2m')
+  })
+
+  it('should support nesting colors', () => {
+    const result = c.bold(c.purple('nested'))
+    expect(result).toContain('nested')
+    expect(result).toContain('\x1b[1m')
+    expect(result).toContain('\x1b[38;2;183;148;244m')
+  })
+})

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -1,0 +1,75 @@
+// @warren/cli — terminal UI helpers (colors, tables, status indicators)
+
+// ── ANSI color codes ────────────────────────────────────────────────────────
+
+const PURPLE = '\x1b[38;2;183;148;244m'
+const CORAL = '\x1b[38;2;242;139;130m'
+const GREEN = '\x1b[32m'
+const YELLOW = '\x1b[33m'
+const RED = '\x1b[31m'
+const DIM = '\x1b[2m'
+const BOLD = '\x1b[1m'
+const RESET = '\x1b[0m'
+
+export const c = {
+  purple: (s: string) => `${PURPLE}${s}${RESET}`,
+  coral: (s: string) => `${CORAL}${s}${RESET}`,
+  green: (s: string) => `${GREEN}${s}${RESET}`,
+  yellow: (s: string) => `${YELLOW}${s}${RESET}`,
+  red: (s: string) => `${RED}${s}${RESET}`,
+  dim: (s: string) => `${DIM}${s}${RESET}`,
+  bold: (s: string) => `${BOLD}${s}${RESET}`,
+}
+
+// ── Status output ───────────────────────────────────────────────────────────
+
+export function banner(): void {
+  console.log(`${c.purple('🐇 warren')} ${c.dim('— your terminal mesh')}`)
+}
+
+export function success(msg: string): void {
+  console.log(`${c.green('✓')} ${msg}`)
+}
+
+export function warn(msg: string): void {
+  console.log(`${c.yellow('!')} ${msg}`)
+}
+
+export function error(msg: string): void {
+  console.error(`${c.red('✗')} ${msg}`)
+}
+
+export function info(msg: string): void {
+  console.log(`${c.purple('→')} ${msg}`)
+}
+
+// ── Table formatting ────────────────────────────────────────────────────────
+
+/** Strip ANSI escape sequences for width calculation */
+function stripAnsi(s: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape sequences use control chars by definition
+  return s.replace(/\x1b\[[0-9;]*m/g, '')
+}
+
+export function table(headers: string[], rows: string[][]): void {
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => stripAnsi(r[i] ?? '').length)),
+  )
+
+  const headerLine = headers.map((h, i) => {
+    const w = widths[i] ?? 0
+    return c.bold(h.padEnd(w))
+  })
+  console.log(headerLine.join('  '))
+  console.log(widths.map((w) => c.dim('─'.repeat(w))).join('  '))
+
+  for (const row of rows) {
+    const padded = row.map((cell, i) => {
+      const visible = stripAnsi(cell).length
+      const w = widths[i] ?? 0
+      const pad = Math.max(0, w - visible)
+      return cell + ' '.repeat(pad)
+    })
+    console.log(padded.join('  '))
+  }
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@warren/config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Adds `packages/cli` (`@warren/cli`) — a full CLI for headless use, scripting, and power users
- Uses **citty** (lightweight, ESM-first CLI framework from UnJS) over commander for minimal bundle size with Bun
- Colorful ANSI terminal output with status indicators (purple/green/red/dim)
- 21 unit tests covering all command helper functions
- CI updated to run CLI tests alongside core tests

## Commands

| Command | Description |
|---------|-------------|
| `warren host start/stop/status` | Manage host mode (foreground server) |
| `warren pair [--pin-only]` | Show QR code + PIN for device pairing |
| `warren devices` / `devices revoke <id>` | List/revoke paired devices |
| `warren connect <host> [--token]` | Interactive terminal session (raw mode) |
| `warren sessions` | List active terminal sessions |
| `warren theme list/set/import/create` | Manage themes (built-in + Hyper import) |
| `warren tunnel status/setup` | Tunnel provider guide (Cloudflare/Tailscale/ngrok) |
| `warren config` / `config set <k> <v>` | Read/write Warren configuration |

## Architecture

- `src/index.ts` — Entry point with citty subcommand routing
- `src/ui.ts` — ANSI color helpers, table formatting, status output
- `src/commands/*.ts` — One file per command group
- `src/test/*.ts` — Unit tests (Bun test runner)
- Depends on `@warren/core` (server, config, devices, pairing, crypto) and `@warren/themes` (theme loader)

## Test plan

- [x] `bun biome check .` passes (no new warnings)
- [x] `bun run typecheck` passes (9/9 tasks)
- [x] `bun test packages/core packages/cli` passes (52 tests, 0 failures)
- [x] `bun run build` passes (6/6 tasks)
- [x] Manual verification: `warren --help`, `warren config`, `warren devices`, `warren theme list`, `warren host status` all produce correct colorful output

Closes #18