### PR TITLE
🐇 feat(sdk): add @warren/sdk programmatic TypeScript API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,22 @@
         "typescript": "latest",
       },
     },
+    "packages/sdk": {
+      "name": "@warren/sdk",
+      "version": "0.1.0",
+      "dependencies": {
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@warren/types": "workspace:*",
+      },
+      "devDependencies": {
+        "@warren/config": "workspace:*",
+        "@warren/core": "workspace:*",
+        "bun-types": "latest",
+        "typescript": "latest",
+      },
+    },
     "packages/themes": {
       "name": "@warren/themes",
       "version": "0.1.0",
@@ -380,7 +396,7 @@
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.3", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA=="],
 
-    "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@noble/curves": ["@noble/curves@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1" } }, "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw=="],
 
@@ -652,6 +668,8 @@
 
     "@warren/docs": ["@warren/docs@workspace:apps/docs"],
 
+    "@warren/sdk": ["@warren/sdk@workspace:packages/sdk"],
+
     "@warren/themes": ["@warren/themes@workspace:packages/themes"],
 
     "@warren/types": ["@warren/types@workspace:packages/types"],
@@ -738,7 +756,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -1906,8 +1924,6 @@
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
-    "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
-
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
@@ -1934,15 +1950,19 @@
 
     "@tanstack/router-utils/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
+    "@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
     "@types/sax/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
+    "@warren/desktop/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "@warren/web/@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "astro/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "bun-types/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1953,8 +1973,6 @@
     "cross-spawn-windows-exe/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
     "cross-spawn-windows-exe/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
-
-    "eciesjs/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "eciesjs/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
@@ -2041,6 +2059,10 @@
     "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "@types/bun/bun-types/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
+    "@warren/desktop/bun-types/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "boxen/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/packages/config/tsconfig.base.json
+++ b/packages/config/tsconfig.base.json
@@ -19,6 +19,7 @@
     "paths": {
       "@warren/types": ["../types/src/index.ts"],
       "@warren/core": ["../core/src/index.ts"],
+      "@warren/sdk": ["../sdk/src/index.ts"],
       "@warren/themes": ["../themes/src/index.ts"]
     }
   }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@warren/sdk",
+  "version": "0.1.0",
+  "description": "Programmatic TypeScript API for Warren",
+  "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir dist --target node",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check ."
+  },
+  "dependencies": {
+    "@noble/ciphers": "^1.3.0",
+    "@noble/curves": "^2.0.1",
+    "@noble/hashes": "^2.0.1",
+    "@warren/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@warren/config": "workspace:*",
+    "@warren/core": "workspace:*",
+    "bun-types": "latest",
+    "typescript": "latest"
+  }
+}

--- a/packages/sdk/src/__tests__/crypto.test.ts
+++ b/packages/sdk/src/__tests__/crypto.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  decryptPayload,
+  deriveSharedSecret,
+  encryptPayload,
+  fromBase64,
+  generateKeyPair,
+  hmacSign,
+  toBase64,
+} from '../crypto'
+import type { SharedSecretRef } from '../types'
+
+describe('base64', () => {
+  test('round-trips bytes', () => {
+    const original = new Uint8Array([0, 1, 127, 128, 255])
+    const encoded = toBase64(original)
+    const decoded = fromBase64(encoded)
+    expect(decoded).toEqual(original)
+  })
+})
+
+describe('hmacSign', () => {
+  test('produces consistent signatures', () => {
+    const secret: SharedSecretRef = { key: crypto.getRandomValues(new Uint8Array(32)) }
+    const sig1 = hmacSign('test-nonce', secret)
+    const sig2 = hmacSign('test-nonce', secret)
+    expect(sig1).toBe(sig2)
+  })
+
+  test('different nonces produce different signatures', () => {
+    const secret: SharedSecretRef = { key: crypto.getRandomValues(new Uint8Array(32)) }
+    const sig1 = hmacSign('nonce-a', secret)
+    const sig2 = hmacSign('nonce-b', secret)
+    expect(sig1).not.toBe(sig2)
+  })
+})
+
+describe('encrypt / decrypt', () => {
+  test('round-trips data', () => {
+    const secret: SharedSecretRef = { key: crypto.getRandomValues(new Uint8Array(32)) }
+    const plaintext = 'Hello, Warren!'
+    const encrypted = encryptPayload(plaintext, secret)
+
+    expect(encrypted.algorithm).toBe('AES-GCM')
+    expect(encrypted.ciphertext).toBeTruthy()
+    expect(encrypted.iv).toBeTruthy()
+
+    const decrypted = decryptPayload(encrypted, secret)
+    expect(decrypted).toBe(plaintext)
+  })
+
+  test('different IVs for same data', () => {
+    const secret: SharedSecretRef = { key: crypto.getRandomValues(new Uint8Array(32)) }
+    const e1 = encryptPayload('same', secret)
+    const e2 = encryptPayload('same', secret)
+    expect(e1.iv).not.toBe(e2.iv)
+  })
+})
+
+describe('ECDH key exchange', () => {
+  test('generateKeyPair returns base64 public key', () => {
+    const kp = generateKeyPair()
+    expect(kp.publicKeyB64).toBeTruthy()
+    expect(kp.privateKey).toBeInstanceOf(Uint8Array)
+    expect(kp.privateKey.length).toBe(32)
+  })
+
+  test('deriveSharedSecret produces matching secrets for both parties', () => {
+    const alice = generateKeyPair()
+    const bob = generateKeyPair()
+
+    const secretA = deriveSharedSecret(alice.privateKey, bob.publicKeyB64)
+    const secretB = deriveSharedSecret(bob.privateKey, alice.publicKeyB64)
+
+    expect(secretA).toBe(secretB)
+  })
+})

--- a/packages/sdk/src/__tests__/emitter.test.ts
+++ b/packages/sdk/src/__tests__/emitter.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { Emitter } from '../emitter'
+
+type TestEvents = {
+  data: [value: string]
+  count: [n: number]
+  empty: []
+}
+
+describe('Emitter', () => {
+  test('on() and emit()', () => {
+    const emitter = new Emitter<TestEvents>()
+    const fn = mock()
+
+    emitter.on('data', fn)
+    emitter.emit('data', 'hello')
+
+    expect(fn).toHaveBeenCalledWith('hello')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  test('on() returns unsubscribe function', () => {
+    const emitter = new Emitter<TestEvents>()
+    const fn = mock()
+
+    const unsub = emitter.on('data', fn)
+    emitter.emit('data', 'first')
+    unsub()
+    emitter.emit('data', 'second')
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith('first')
+  })
+
+  test('once() fires only once', () => {
+    const emitter = new Emitter<TestEvents>()
+    const fn = mock()
+
+    emitter.once('count', fn)
+    emitter.emit('count', 1)
+    emitter.emit('count', 2)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith(1)
+  })
+
+  test('multiple listeners on same event', () => {
+    const emitter = new Emitter<TestEvents>()
+    const fn1 = mock()
+    const fn2 = mock()
+
+    emitter.on('data', fn1)
+    emitter.on('data', fn2)
+    emitter.emit('data', 'both')
+
+    expect(fn1).toHaveBeenCalledWith('both')
+    expect(fn2).toHaveBeenCalledWith('both')
+  })
+
+  test('events with no args', () => {
+    const emitter = new Emitter<TestEvents>()
+    const fn = mock()
+
+    emitter.on('empty', fn)
+    emitter.emit('empty')
+
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  test('removeAllListeners() clears specific event', () => {
+    const emitter = new Emitter<TestEvents>()
+    const dataFn = mock()
+    const countFn = mock()
+
+    emitter.on('data', dataFn)
+    emitter.on('count', countFn)
+    emitter.removeAllListeners('data')
+    emitter.emit('data', 'gone')
+    emitter.emit('count', 42)
+
+    expect(dataFn).not.toHaveBeenCalled()
+    expect(countFn).toHaveBeenCalledWith(42)
+  })
+
+  test('removeAllListeners() with no args clears everything', () => {
+    const emitter = new Emitter<TestEvents>()
+    const fn1 = mock()
+    const fn2 = mock()
+
+    emitter.on('data', fn1)
+    emitter.on('count', fn2)
+    emitter.removeAllListeners()
+    emitter.emit('data', 'gone')
+    emitter.emit('count', 0)
+
+    expect(fn1).not.toHaveBeenCalled()
+    expect(fn2).not.toHaveBeenCalled()
+  })
+
+  test('emit on event with no listeners does not throw', () => {
+    const emitter = new Emitter<TestEvents>()
+    expect(() => emitter.emit('data', 'safe')).not.toThrow()
+  })
+})

--- a/packages/sdk/src/__tests__/http.test.ts
+++ b/packages/sdk/src/__tests__/http.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { WarrenHttp } from '../http'
+import type { DeviceInfo } from '../types'
+
+// biome-ignore lint/suspicious/noExplicitAny: mock fetch requires flexible typing
+function mockFetch(response: () => Promise<Response>): any {
+  return Object.assign(mock(response), { preconnect: mock() })
+}
+
+describe('WarrenHttp', () => {
+  test('constructs correct base URL', () => {
+    const http = new WarrenHttp('192.168.1.10', 9470)
+    expect(http).toBeDefined()
+  })
+
+  test('getHealth calls /health endpoint', async () => {
+    const mockResponse = {
+      status: 'ok',
+      version: '0.2.0',
+      nodeId: 'test-id',
+      uptime: 100,
+      sessions: 0,
+    }
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mockFetch(async () => new Response(JSON.stringify(mockResponse)))
+
+    try {
+      const http = new WarrenHttp('localhost', 9470)
+      const health = await http.getHealth()
+
+      expect(health).toEqual(mockResponse)
+      expect(globalThis.fetch).toHaveBeenCalledWith('http://localhost:9470/health', undefined)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test('listDevices calls /api/devices endpoint', async () => {
+    const mockDevices: DeviceInfo[] = [
+      { id: 'd1', name: 'device-1', pairedAt: 1000, lastSeen: 2000, permission: 'full' },
+    ]
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mockFetch(async () => new Response(JSON.stringify(mockDevices)))
+
+    try {
+      const http = new WarrenHttp('localhost', 9470)
+      const devices = await http.listDevices()
+
+      expect(devices).toEqual(mockDevices)
+      expect(globalThis.fetch).toHaveBeenCalledWith('http://localhost:9470/api/devices', undefined)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test('throws on non-ok response', async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mockFetch(async () => new Response('Not found', { status: 404 }))
+
+    try {
+      const http = new WarrenHttp('localhost', 9470)
+      await expect(http.getHealth()).rejects.toThrow('Warren HTTP 404')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test('updateConfig sends PATCH request', async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mockFetch(async () => new Response(JSON.stringify({ ok: true })))
+
+    try {
+      const http = new WarrenHttp('localhost', 9470)
+      await http.updateConfig({ theme: 'dark' })
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'http://localhost:9470/api/config',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ theme: 'dark' }),
+        }),
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})

--- a/packages/sdk/src/__tests__/integration.test.ts
+++ b/packages/sdk/src/__tests__/integration.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { startServer } from '@warren/core'
+import { Warren } from '../warren'
+
+const TEST_PORT = 19470
+const TEST_TOKEN = 'sdk-test-token'
+
+let server: ReturnType<typeof startServer>
+
+beforeAll(() => {
+  server = startServer({
+    port: TEST_PORT,
+    token: TEST_TOKEN,
+    config: {
+      nodeId: 'sdk-test-node',
+      hostMode: false,
+      shell: '/bin/sh',
+      port: TEST_PORT,
+      theme: 'tokyo-night',
+      logging: false,
+    },
+  })
+})
+
+afterAll(async () => {
+  await server.stop(true)
+})
+
+describe('Warren SDK integration', () => {
+  test('connect and disconnect with token auth', async () => {
+    const warren = new Warren({
+      host: 'localhost',
+      port: TEST_PORT,
+      token: TEST_TOKEN,
+      autoReconnect: false,
+    })
+
+    await warren.connect()
+    expect(warren.isConnected).toBe(true)
+
+    warren.disconnect()
+    expect(warren.isConnected).toBe(false)
+  })
+
+  test('getHealth returns server info', async () => {
+    const warren = new Warren({
+      host: 'localhost',
+      port: TEST_PORT,
+      token: TEST_TOKEN,
+      autoReconnect: false,
+    })
+
+    const health = await warren.getHealth()
+    expect(health.status).toBe('ok')
+    expect(health.nodeId).toBe('sdk-test-node')
+    expect(typeof health.uptime).toBe('number')
+
+    warren.disconnect()
+  })
+
+  test('createSession, write, receive data, kill', async () => {
+    const warren = new Warren({
+      host: 'localhost',
+      port: TEST_PORT,
+      token: TEST_TOKEN,
+      autoReconnect: false,
+    })
+
+    await warren.connect()
+
+    const session = await warren.createSession({ shell: '/bin/sh' })
+    expect(session.id).toBeTruthy()
+    expect(session.info.shell).toBe('/bin/sh')
+
+    // Collect output
+    const output: string[] = []
+    session.onData((data) => output.push(data))
+
+    // Write a command that produces known output
+    session.write('echo SDK_TEST_OK\n')
+
+    // Wait for output
+    await new Promise<void>((resolve) => {
+      const check = setInterval(() => {
+        if (output.join('').includes('SDK_TEST_OK')) {
+          clearInterval(check)
+          resolve()
+        }
+      }, 50)
+      // Timeout after 5s
+      setTimeout(() => {
+        clearInterval(check)
+        resolve()
+      }, 5000)
+    })
+
+    expect(output.join('')).toContain('SDK_TEST_OK')
+
+    // Kill the session
+    await session.kill()
+    expect(session.isEnded).toBe(true)
+
+    warren.disconnect()
+  })
+
+  test('resize sends without error', async () => {
+    const warren = new Warren({
+      host: 'localhost',
+      port: TEST_PORT,
+      token: TEST_TOKEN,
+      autoReconnect: false,
+    })
+
+    await warren.connect()
+
+    const session = await warren.createSession()
+    session.resize(120, 40)
+
+    // No error means success
+    await session.kill()
+    warren.disconnect()
+  })
+
+  test('listRemoteSessions returns sessions', async () => {
+    const warren = new Warren({
+      host: 'localhost',
+      port: TEST_PORT,
+      token: TEST_TOKEN,
+      autoReconnect: false,
+    })
+
+    await warren.connect()
+    const session = await warren.createSession()
+
+    const sessions = await warren.listRemoteSessions()
+    expect(sessions.length).toBeGreaterThanOrEqual(1)
+    expect(sessions.some((s) => s.id === session.id)).toBe(true)
+
+    await session.kill()
+    warren.disconnect()
+  })
+
+  test('events fire correctly', async () => {
+    const warren = new Warren({
+      host: 'localhost',
+      port: TEST_PORT,
+      token: TEST_TOKEN,
+      autoReconnect: false,
+    })
+
+    let connected = false
+    let sessionCreated = false
+    let sessionEnded = false
+
+    warren.on('connected', () => {
+      connected = true
+    })
+    warren.on('session:created', () => {
+      sessionCreated = true
+    })
+    warren.on('session:ended', () => {
+      sessionEnded = true
+    })
+
+    await warren.connect()
+    expect(connected).toBe(true)
+
+    const session = await warren.createSession()
+    expect(sessionCreated).toBe(true)
+
+    await session.kill()
+    // Give a tick for the event to fire
+    await new Promise((r) => setTimeout(r, 100))
+    expect(sessionEnded).toBe(true)
+
+    warren.disconnect()
+  })
+})

--- a/packages/sdk/src/crypto.ts
+++ b/packages/sdk/src/crypto.ts
@@ -1,0 +1,95 @@
+// Cryptographic utilities for the SDK
+//
+// Uses @noble/ciphers + @noble/hashes for synchronous, cross-platform crypto.
+// No crypto.subtle required — works in Bun, Node.js, and browsers.
+
+import { gcm } from '@noble/ciphers/aes.js'
+import { x25519 } from '@noble/curves/ed25519.js'
+import { hkdf } from '@noble/hashes/hkdf.js'
+import { hmac } from '@noble/hashes/hmac.js'
+import { sha256 } from '@noble/hashes/sha2.js'
+import type { EncryptedPayload } from '@warren/types'
+import type { SharedSecretRef } from './types'
+
+// ---------------------------------------------------------------------------
+// Base64 helpers
+// ---------------------------------------------------------------------------
+
+export function toBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+}
+
+export function fromBase64(b64: string): Uint8Array {
+  const binary = atob(b64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+// ---------------------------------------------------------------------------
+// HKDF constants — must match packages/core/src/crypto.ts
+// ---------------------------------------------------------------------------
+
+const HKDF_SALT = new TextEncoder().encode('warren-v0.2')
+const HKDF_INFO = new TextEncoder().encode('ecdh-shared-secret')
+
+// ---------------------------------------------------------------------------
+// HMAC-SHA256 — synchronous challenge signing for reconnection auth
+// ---------------------------------------------------------------------------
+
+/** Sign a nonce with HMAC-SHA256 using the shared secret. */
+export function hmacSign(nonce: string, secret: SharedSecretRef): string {
+  const data = new TextEncoder().encode(nonce)
+  const sig = hmac(sha256, secret.key, data)
+  return toBase64(sig)
+}
+
+// ---------------------------------------------------------------------------
+// AES-256-GCM — synchronous encrypt/decrypt
+// ---------------------------------------------------------------------------
+
+/** Encrypt a string payload with AES-256-GCM. */
+export function encryptPayload(data: string, secret: SharedSecretRef): EncryptedPayload {
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const encoded = new TextEncoder().encode(data)
+  const encrypted = gcm(secret.key, iv).encrypt(encoded)
+  return { ciphertext: toBase64(encrypted), iv: toBase64(iv), algorithm: 'AES-GCM' }
+}
+
+/** Decrypt an AES-256-GCM encrypted payload. */
+export function decryptPayload(encrypted: EncryptedPayload, secret: SharedSecretRef): string {
+  const iv = fromBase64(encrypted.iv)
+  const ciphertext = fromBase64(encrypted.ciphertext)
+  const decrypted = gcm(secret.key, iv).decrypt(ciphertext)
+  return new TextDecoder().decode(decrypted)
+}
+
+// ---------------------------------------------------------------------------
+// X25519 ECDH — for pairing flow
+// ---------------------------------------------------------------------------
+
+export interface KeyPair {
+  publicKeyB64: string
+  privateKey: Uint8Array
+}
+
+/** Generate an ephemeral X25519 key pair for pairing. */
+export function generateKeyPair(): KeyPair {
+  const privateKey = x25519.utils.randomSecretKey()
+  return {
+    publicKeyB64: toBase64(x25519.getPublicKey(privateKey)),
+    privateKey,
+  }
+}
+
+/** Derive a shared secret from an X25519 key exchange. Returns base64-encoded secret. */
+export function deriveSharedSecret(privateKey: Uint8Array, peerPublicKeyB64: string): string {
+  const rawSecret = x25519.getSharedSecret(privateKey, fromBase64(peerPublicKeyB64))
+  return toBase64(hkdf(sha256, rawSecret, HKDF_SALT, HKDF_INFO, 32))
+}

--- a/packages/sdk/src/emitter.ts
+++ b/packages/sdk/src/emitter.ts
@@ -1,0 +1,56 @@
+// Minimal typed event emitter — no Node.js dependency
+
+// biome-ignore lint/suspicious/noExplicitAny: event emitter requires flexible typing
+type Listener = (...args: any[]) => void
+
+/**
+ * Lightweight typed event emitter.
+ *
+ * @example
+ * ```ts
+ * const emitter = new Emitter<{ data: [string]; close: [] }>()
+ * emitter.on('data', (chunk) => console.log(chunk))
+ * emitter.emit('data', 'hello')
+ * ```
+ */
+export class Emitter<Events extends Record<string, unknown[]>> {
+  private listeners = new Map<keyof Events, Set<Listener>>()
+
+  /** Subscribe to an event. Returns an unsubscribe function. */
+  on<K extends keyof Events>(event: K, listener: (...args: Events[K]) => void): () => void {
+    let set = this.listeners.get(event)
+    if (!set) {
+      set = new Set()
+      this.listeners.set(event, set)
+    }
+    set.add(listener as Listener)
+    return () => set.delete(listener as Listener)
+  }
+
+  /** Subscribe to an event, but only fire once. */
+  once<K extends keyof Events>(event: K, listener: (...args: Events[K]) => void): () => void {
+    const unsub = this.on(event, ((...args: Events[K]) => {
+      unsub()
+      listener(...args)
+    }) as (...args: Events[K]) => void)
+    return unsub
+  }
+
+  /** Emit an event with the given arguments. */
+  emit<K extends keyof Events>(event: K, ...args: Events[K]): void {
+    const set = this.listeners.get(event)
+    if (!set) return
+    for (const listener of set) {
+      listener(...args)
+    }
+  }
+
+  /** Remove all listeners (or all listeners for a specific event). */
+  removeAllListeners(event?: keyof Events): void {
+    if (event) {
+      this.listeners.delete(event)
+    } else {
+      this.listeners.clear()
+    }
+  }
+}

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -1,0 +1,96 @@
+// HTTP client for Warren REST API endpoints
+
+import type {
+  ConfigResponse,
+  DeviceInfo,
+  DiscoverNode,
+  HealthResponse,
+  PairStartResponse,
+  WarrenConfig,
+} from './types'
+
+/**
+ * HTTP client for the Warren REST API.
+ *
+ * Wraps all REST endpoints exposed by the Warren server. Used internally by
+ * the `Warren` class but also available standalone for lightweight usage.
+ */
+export class WarrenHttp {
+  private readonly baseUrl: string
+
+  constructor(host: string, port: number) {
+    this.baseUrl = `http://${host}:${port}`
+  }
+
+  /** GET /health — server health check. */
+  async getHealth(): Promise<HealthResponse> {
+    return this.get('/health')
+  }
+
+  /** GET /api/devices — list paired devices. */
+  async listDevices(): Promise<DeviceInfo[]> {
+    return this.get('/api/devices')
+  }
+
+  /** DELETE /api/devices/:id — remove a paired device. */
+  async removeDevice(deviceId: string): Promise<void> {
+    await this.fetch(`/api/devices/${deviceId}`, { method: 'DELETE' })
+  }
+
+  /** PATCH /api/devices/:id/revoke — revoke device access. */
+  async revokeDevice(deviceId: string): Promise<void> {
+    await this.fetch(`/api/devices/${deviceId}/revoke`, { method: 'PATCH' })
+  }
+
+  /** GET /api/sessions — list active terminal sessions. */
+  async listSessions(): Promise<import('@warren/types').TerminalSession[]> {
+    return this.get('/api/sessions')
+  }
+
+  /** DELETE /api/sessions/:id — kill a terminal session. */
+  async killSession(sessionId: string): Promise<void> {
+    await this.fetch(`/api/sessions/${sessionId}`, { method: 'DELETE' })
+  }
+
+  /** GET /api/pair/start — initiate device pairing (returns QR + PIN). */
+  async startPairing(): Promise<PairStartResponse> {
+    return this.get('/api/pair/start')
+  }
+
+  /** GET /api/discover — discover Warren nodes on the LAN. */
+  async discover(): Promise<DiscoverNode[]> {
+    return this.get('/api/discover')
+  }
+
+  /** GET /api/config — read server configuration. */
+  async getConfig(): Promise<ConfigResponse> {
+    return this.get('/api/config')
+  }
+
+  /** PATCH /api/config — update server configuration. */
+  async updateConfig(partial: Partial<Omit<WarrenConfig, 'nodeId'>>): Promise<void> {
+    await this.fetch('/api/config', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(partial),
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  private async get<T>(path: string): Promise<T> {
+    const res = await this.fetch(path)
+    return res.json() as Promise<T>
+  }
+
+  private async fetch(path: string, init?: RequestInit): Promise<Response> {
+    const res = await globalThis.fetch(`${this.baseUrl}${path}`, init)
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw new Error(`Warren HTTP ${res.status}: ${path} — ${body}`)
+    }
+    return res
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,30 @@
+// @warren/sdk — programmatic TypeScript API for Warren
+
+// Re-export shared types from @warren/types
+// Re-export WsMessage for advanced usage
+export type {
+  EncryptedPayload,
+  PairedDevice,
+  TerminalSession,
+  WarrenConfig,
+  WsMessage,
+} from '@warren/types'
+// Crypto utilities for advanced usage (pairing flows)
+export { deriveSharedSecret, generateKeyPair } from './crypto'
+export { Emitter } from './emitter'
+export { WarrenHttp } from './http'
+export { Session } from './session'
+// Re-export SDK types
+export type {
+  ConfigResponse,
+  CreateSessionOptions,
+  DeviceInfo,
+  DiscoverNode,
+  HealthResponse,
+  PairStartResponse,
+  SessionEvents,
+  WarrenEvents,
+  WarrenOptions,
+} from './types'
+export { Warren } from './warren'
+export { WarrenWs } from './ws'

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -1,0 +1,109 @@
+// Terminal session handle — wraps a remote PTY session over WebSocket
+
+import type { TerminalSession } from '@warren/types'
+import { Emitter } from './emitter'
+import type { SessionEvents } from './types'
+import type { WarrenWs } from './ws'
+
+/**
+ * A handle to a remote terminal session.
+ *
+ * Created via `warren.createSession()`. Provides methods to write data,
+ * listen for output, resize the terminal, and kill the session.
+ *
+ * @example
+ * ```ts
+ * const session = await warren.createSession({ shell: '/bin/zsh' })
+ * session.onData((data) => process.stdout.write(data))
+ * session.write('ls -la\n')
+ * session.resize(120, 40)
+ * await session.kill()
+ * ```
+ */
+export class Session extends Emitter<SessionEvents> {
+  /** The underlying session metadata from the server. */
+  readonly info: TerminalSession
+
+  private readonly ws: WarrenWs
+  private readonly unsub: () => void
+  private ended = false
+
+  constructor(info: TerminalSession, ws: WarrenWs) {
+    super()
+    this.info = info
+    this.ws = ws
+
+    // Subscribe to WS messages for this session
+    this.unsub = ws.on('message', (msg) => {
+      if (msg.type === 'terminal:data' && msg.sessionId === this.info.id) {
+        this.emit('data', msg.data)
+      }
+      if (msg.type === 'session:ended' && msg.sessionId === this.info.id) {
+        this.ended = true
+        this.emit('ended')
+        this.unsub()
+      }
+    })
+  }
+
+  /** The session ID. */
+  get id(): string {
+    return this.info.id
+  }
+
+  /** Whether this session has ended. */
+  get isEnded(): boolean {
+    return this.ended
+  }
+
+  /** Write data to the session's stdin. */
+  write(data: string): void {
+    if (this.ended) return
+    this.ws.send({ type: 'terminal:data', sessionId: this.info.id, data })
+  }
+
+  /**
+   * Subscribe to terminal output data.
+   *
+   * @returns Unsubscribe function.
+   */
+  onData(handler: (data: string) => void): () => void {
+    return this.on('data', handler)
+  }
+
+  /**
+   * Subscribe to session end event.
+   *
+   * @returns Unsubscribe function.
+   */
+  onEnd(handler: () => void): () => void {
+    return this.on('ended', handler)
+  }
+
+  /** Resize the terminal. */
+  resize(cols: number, rows: number): void {
+    if (this.ended) return
+    this.ws.send({ type: 'terminal:resize', sessionId: this.info.id, cols, rows })
+  }
+
+  /**
+   * Kill the session.
+   *
+   * Resolves when the server confirms the session has ended.
+   * If the session is already ended, resolves immediately.
+   */
+  kill(): Promise<void> {
+    if (this.ended) return Promise.resolve()
+
+    return new Promise<void>((resolve) => {
+      this.once('ended', () => resolve())
+      this.ws.send({ type: 'session:kill', sessionId: this.info.id })
+    })
+  }
+
+  /** Clean up internal subscriptions. */
+  dispose(): void {
+    this.unsub()
+    this.removeAllListeners()
+  }
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,0 +1,113 @@
+// @warren/sdk — SDK-specific types and interfaces
+
+import type { EncryptedPayload, PairedDevice, TerminalSession, WarrenConfig } from '@warren/types'
+
+// ---------------------------------------------------------------------------
+// Connection options
+// ---------------------------------------------------------------------------
+
+/** Options for connecting to a Warren host. */
+export interface WarrenOptions {
+  /** Host address (IP or hostname). */
+  host: string
+  /** Port number (default: 9470). */
+  port?: number
+  /** v0.1 auth token. Mutually exclusive with keypair auth. */
+  token?: string
+  /** v0.2 keypair auth credentials. Mutually exclusive with token. */
+  keypair?: {
+    deviceId: string
+    /** Base64-encoded shared secret (from prior pairing). */
+    sharedSecret: string
+  }
+  /** Auto-reconnect on disconnect (default: true). */
+  autoReconnect?: boolean
+  /** Max reconnect attempts before giving up (default: Infinity). */
+  maxReconnectAttempts?: number
+  /** Base delay in ms for reconnect backoff (default: 1000). */
+  reconnectBaseDelay?: number
+}
+
+/** Options for creating a new terminal session. */
+export interface CreateSessionOptions {
+  /** Shell to launch (e.g. "/bin/zsh"). Server default if omitted. */
+  shell?: string
+}
+
+// ---------------------------------------------------------------------------
+// Event maps
+// ---------------------------------------------------------------------------
+
+/** Events emitted by the Warren client. */
+export type WarrenEvents = {
+  connected: []
+  disconnected: []
+  error: [error: Error]
+  'session:created': [session: TerminalSession]
+  'session:ended': [sessionId: string]
+}
+
+/** Events emitted by a terminal session. */
+export type SessionEvents = {
+  data: [data: string]
+  ended: []
+}
+
+// ---------------------------------------------------------------------------
+// HTTP response types
+// ---------------------------------------------------------------------------
+
+/** Response from GET /health. */
+export interface HealthResponse {
+  status: string
+  version: string
+  nodeId: string
+  uptime: number
+  sessions: number
+}
+
+/** Device info returned by GET /api/devices (public subset of PairedDevice). */
+export interface DeviceInfo {
+  id: string
+  name: string
+  pairedAt: number
+  lastSeen: number
+  permission: PairedDevice['permission']
+}
+
+/** Response from GET /api/pair/start. */
+export interface PairStartResponse {
+  pin: string
+  expiresAt: number
+  pairUrl: string
+  qrSvg: string
+}
+
+/** Response from GET /api/discover. */
+export interface DiscoverNode {
+  version: string
+  nodeId: string
+  hostName: string
+  hostMode: boolean
+  port: number
+}
+
+/** Public config fields returned by GET /api/config. */
+export interface ConfigResponse {
+  shell: string
+  port: number
+  hostMode: boolean
+  theme: string
+  logging: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+/** Shared secret reference for encryption. */
+export interface SharedSecretRef {
+  key: Uint8Array
+}
+
+export type { EncryptedPayload, PairedDevice, TerminalSession, WarrenConfig }

--- a/packages/sdk/src/warren.ts
+++ b/packages/sdk/src/warren.ts
@@ -1,0 +1,201 @@
+// Warren — main SDK entry point
+//
+// Provides a high-level programmatic API for interacting with a Warren host.
+// Wraps the WebSocket protocol and HTTP REST API into a single, ergonomic class.
+
+import type { TerminalSession, WarrenConfig } from '@warren/types'
+import { Emitter } from './emitter'
+import { WarrenHttp } from './http'
+import { Session } from './session'
+import type {
+  ConfigResponse,
+  CreateSessionOptions,
+  DeviceInfo,
+  DiscoverNode,
+  HealthResponse,
+  PairStartResponse,
+  WarrenEvents,
+  WarrenOptions,
+} from './types'
+import { WarrenWs } from './ws'
+
+/**
+ * Programmatic TypeScript client for Warren.
+ *
+ * Provides both WebSocket-based terminal sessions and HTTP-based management
+ * operations through a single unified API.
+ *
+ * @example
+ * ```ts
+ * import { Warren } from '@warren/sdk'
+ *
+ * const warren = new Warren({ host: 'localhost', port: 9470, token: '...' })
+ * await warren.connect()
+ *
+ * const session = await warren.createSession({ shell: '/bin/zsh' })
+ * session.onData((data) => process.stdout.write(data))
+ * session.write('ls -la\n')
+ * session.resize(120, 40)
+ * await session.kill()
+ *
+ * const health = await warren.getHealth()
+ * const devices = await warren.listDevices()
+ *
+ * warren.disconnect()
+ * ```
+ */
+export class Warren extends Emitter<WarrenEvents> {
+  private readonly ws: WarrenWs
+  private readonly http: WarrenHttp
+  private readonly sessions = new Map<string, Session>()
+
+  constructor(options: WarrenOptions) {
+    super()
+    const port = options.port ?? 9470
+
+    this.ws = new WarrenWs(options)
+    this.http = new WarrenHttp(options.host, port)
+
+    // Forward WS events
+    this.ws.on('authenticated', () => this.emit('connected'))
+    this.ws.on('close', () => this.emit('disconnected'))
+    this.ws.on('error', (err) => this.emit('error', err))
+
+    // Track session lifecycle from WS messages
+    this.ws.on('message', (msg) => {
+      if (msg.type === 'session:created') {
+        this.emit('session:created', msg.session)
+      }
+      if (msg.type === 'session:ended') {
+        const session = this.sessions.get(msg.sessionId)
+        if (session) {
+          this.sessions.delete(msg.sessionId)
+        }
+        this.emit('session:ended', msg.sessionId)
+      }
+    })
+  }
+
+  /** Whether the WebSocket connection is currently open. */
+  get isConnected(): boolean {
+    return this.ws.isConnected
+  }
+
+  // -------------------------------------------------------------------------
+  // Connection
+  // -------------------------------------------------------------------------
+
+  /**
+   * Connect to the Warren host and authenticate.
+   *
+   * Resolves once the auth handshake is complete. Rejects on auth failure
+   * or connection error.
+   */
+  async connect(): Promise<void> {
+    await this.ws.connect()
+  }
+
+  /** Disconnect from the Warren host and clean up all sessions. */
+  disconnect(): void {
+    for (const session of this.sessions.values()) {
+      session.dispose()
+    }
+    this.sessions.clear()
+    this.ws.disconnect()
+  }
+
+  // -------------------------------------------------------------------------
+  // Terminal sessions (WebSocket)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Create a new remote terminal session.
+   *
+   * @param options - Optional session configuration.
+   * @returns A `Session` handle for interacting with the terminal.
+   */
+  createSession(options?: CreateSessionOptions): Promise<Session> {
+    return new Promise<Session>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        unsub()
+        reject(new Error('Timed out waiting for session:created'))
+      }, 10_000)
+
+      const unsub = this.ws.on('message', (msg) => {
+        if (msg.type === 'session:created') {
+          clearTimeout(timeout)
+          unsub()
+          const session = new Session(msg.session, this.ws)
+          this.sessions.set(session.id, session)
+          resolve(session)
+        }
+      })
+
+      this.ws.send({ type: 'session:create', shell: options?.shell })
+    })
+  }
+
+  /** Get a session by ID (only locally tracked sessions). */
+  getSession(sessionId: string): Session | undefined {
+    return this.sessions.get(sessionId)
+  }
+
+  /** Get all locally tracked sessions. */
+  getSessions(): Session[] {
+    return [...this.sessions.values()]
+  }
+
+  // -------------------------------------------------------------------------
+  // HTTP API
+  // -------------------------------------------------------------------------
+
+  /** GET /health — check server health. */
+  async getHealth(): Promise<HealthResponse> {
+    return this.http.getHealth()
+  }
+
+  /** GET /api/devices — list paired devices. */
+  async listDevices(): Promise<DeviceInfo[]> {
+    return this.http.listDevices()
+  }
+
+  /** DELETE /api/devices/:id — remove a paired device. */
+  async removeDevice(deviceId: string): Promise<void> {
+    return this.http.removeDevice(deviceId)
+  }
+
+  /** PATCH /api/devices/:id/revoke — revoke device access. */
+  async revokeDevice(deviceId: string): Promise<void> {
+    return this.http.revokeDevice(deviceId)
+  }
+
+  /** GET /api/sessions — list active sessions on the server. */
+  async listRemoteSessions(): Promise<TerminalSession[]> {
+    return this.http.listSessions()
+  }
+
+  /** DELETE /api/sessions/:id — kill a session via HTTP. */
+  async killRemoteSession(sessionId: string): Promise<void> {
+    return this.http.killSession(sessionId)
+  }
+
+  /** GET /api/pair/start — initiate device pairing. */
+  async startPairing(): Promise<PairStartResponse> {
+    return this.http.startPairing()
+  }
+
+  /** GET /api/discover — discover Warren nodes on the LAN. */
+  async discover(): Promise<DiscoverNode[]> {
+    return this.http.discover()
+  }
+
+  /** GET /api/config — read server config. */
+  async getConfig(): Promise<ConfigResponse> {
+    return this.http.getConfig()
+  }
+
+  /** PATCH /api/config — update server config. */
+  async updateConfig(partial: Partial<Omit<WarrenConfig, 'nodeId'>>): Promise<void> {
+    return this.http.updateConfig(partial)
+  }
+}

--- a/packages/sdk/src/ws.ts
+++ b/packages/sdk/src/ws.ts
@@ -1,0 +1,245 @@
+// WebSocket client for the Warren WsMessage protocol
+//
+// Supports:
+//   - v0.1 token auth
+//   - v0.2 keypair auth (HMAC challenge-response)
+//   - AES-256-GCM encrypted transport
+//   - Auto-reconnect with exponential backoff
+
+import type { EncryptedPayload, WsMessage } from '@warren/types'
+import { decryptPayload, encryptPayload, fromBase64, hmacSign } from './crypto'
+import { Emitter } from './emitter'
+import type { SharedSecretRef, WarrenOptions } from './types'
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+type WsEvents = {
+  open: []
+  close: []
+  authenticated: []
+  message: [msg: WsMessage]
+  error: [error: Error]
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket client
+// ---------------------------------------------------------------------------
+
+/**
+ * Low-level WebSocket client with Warren auth and encryption.
+ *
+ * Used internally by the `Warren` class. Handles the auth handshake
+ * automatically on connect and transparently encrypts/decrypts messages
+ * when a shared secret is present.
+ */
+export class WarrenWs extends Emitter<WsEvents> {
+  private ws: WebSocket | null = null
+  private sharedSecret: SharedSecretRef | null = null
+  private shouldReconnect = false
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempt = 0
+  private readonly opts: Required<
+    Pick<
+      WarrenOptions,
+      'host' | 'port' | 'autoReconnect' | 'maxReconnectAttempts' | 'reconnectBaseDelay'
+    >
+  > &
+    Pick<WarrenOptions, 'token' | 'keypair'>
+
+  constructor(options: WarrenOptions) {
+    super()
+    this.opts = {
+      host: options.host,
+      port: options.port ?? 9470,
+      token: options.token,
+      keypair: options.keypair,
+      autoReconnect: options.autoReconnect ?? true,
+      maxReconnectAttempts: options.maxReconnectAttempts ?? Number.POSITIVE_INFINITY,
+      reconnectBaseDelay: options.reconnectBaseDelay ?? 1000,
+    }
+
+    if (options.keypair) {
+      this.sharedSecret = { key: fromBase64(options.keypair.sharedSecret) }
+    }
+  }
+
+  /** Whether the WebSocket is currently open. */
+  get isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN
+  }
+
+  /**
+   * Open the WebSocket connection and perform auth.
+   *
+   * Resolves once authenticated. Rejects on auth failure or connection error.
+   */
+  connect(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.shouldReconnect = this.opts.autoReconnect
+      this.reconnectAttempt = 0
+      this.createSocket(resolve, reject)
+    })
+  }
+
+  /** Close the connection and stop auto-reconnect. */
+  disconnect(): void {
+    this.shouldReconnect = false
+    this.clearReconnectTimer()
+    if (this.ws) {
+      this.ws.onclose = null
+      this.ws.close()
+      this.ws = null
+    }
+    this.emit('close')
+  }
+
+  /** Send a typed WsMessage, encrypting if a shared secret is set. */
+  send(msg: WsMessage): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return
+
+    if (this.sharedSecret) {
+      const payload = encryptPayload(JSON.stringify(msg), this.sharedSecret)
+      this.ws.send(JSON.stringify({ type: 'encrypted:message', payload }))
+    } else {
+      this.ws.send(JSON.stringify(msg))
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal
+  // -------------------------------------------------------------------------
+
+  private buildUrl(): string {
+    const base = `ws://${this.opts.host}:${this.opts.port}/ws`
+    if (this.opts.keypair) {
+      return `${base}?deviceId=${encodeURIComponent(this.opts.keypair.deviceId)}`
+    }
+    if (this.opts.token) {
+      return `${base}?token=${encodeURIComponent(this.opts.token)}`
+    }
+    return base
+  }
+
+  private createSocket(onAuth?: () => void, onFail?: (reason: Error) => void): void {
+    this.clearReconnectTimer()
+
+    try {
+      const url = this.buildUrl()
+      this.ws = new WebSocket(url)
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err))
+      this.emit('error', error)
+      onFail?.(error)
+      return
+    }
+
+    let authenticated = false
+
+    this.ws.onopen = () => {
+      this.reconnectAttempt = 0
+      this.emit('open')
+    }
+
+    this.ws.onmessage = (event: MessageEvent) => {
+      try {
+        const raw = typeof event.data === 'string' ? event.data : String(event.data)
+        let msg = JSON.parse(raw) as WsMessage
+
+        // Decrypt envelope if needed
+        if (msg.type === 'encrypted:message' && this.sharedSecret) {
+          const inner = decryptPayload(
+            (msg as { type: string; payload: EncryptedPayload }).payload,
+            this.sharedSecret,
+          )
+          msg = JSON.parse(inner) as WsMessage
+        }
+
+        // Handle auth flow
+        if (!authenticated) {
+          if (msg.type === 'auth:challenge') {
+            this.handleChallenge(msg.nonce)
+            return
+          }
+          if (msg.type === 'auth:success') {
+            authenticated = true
+            this.emit('authenticated')
+            onAuth?.()
+            // Clear the callbacks so reconnect doesn't resolve old promises
+            onAuth = undefined
+            onFail = undefined
+            return
+          }
+          if (msg.type === 'auth:failure') {
+            const error = new Error(`Auth failed: ${msg.reason}`)
+            this.emit('error', error)
+            onFail?.(error)
+            onAuth = undefined
+            onFail = undefined
+            return
+          }
+        }
+
+        // Post-auth messages
+        this.emit('message', msg)
+      } catch {
+        // Ignore malformed messages
+      }
+    }
+
+    this.ws.onclose = () => {
+      this.ws = null
+      this.emit('close')
+
+      if (!authenticated) {
+        onFail?.(new Error('WebSocket closed before authentication'))
+        onAuth = undefined
+        onFail = undefined
+      }
+
+      this.scheduleReconnect()
+    }
+
+    this.ws.onerror = () => {
+      // onclose fires after onerror, reconnect is handled there
+    }
+  }
+
+  private handleChallenge(nonce: string): void {
+    if (this.opts.keypair && this.sharedSecret) {
+      // v0.2 keypair auth: HMAC-sign the nonce
+      const signature = hmacSign(nonce, this.sharedSecret)
+      this.send({ type: 'auth:response', signature, deviceId: this.opts.keypair.deviceId })
+    } else if (this.opts.token) {
+      // v0.1 token auth: send token as signature
+      this.send({
+        type: 'auth:response',
+        signature: this.opts.token,
+        deviceId: crypto.randomUUID(),
+      })
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.shouldReconnect) return
+    if (this.reconnectAttempt >= this.opts.maxReconnectAttempts) {
+      this.emit('error', new Error('Max reconnect attempts reached'))
+      return
+    }
+
+    const delay = Math.min(this.opts.reconnectBaseDelay * 2 ** this.reconnectAttempt, 30_000)
+    this.reconnectAttempt++
+
+    this.reconnectTimer = setTimeout(() => {
+      this.createSocket()
+    }, delay)
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+  }
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@warren/config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Implements `@warren/sdk` — a programmatic TypeScript API for building on top of Warren. Foundation for the MCP server (#21).

- **`Warren`** class — connect, createSession, disconnect, event emitter pattern
- **`Session`** class — write, onData, resize, kill for terminal sessions
- **`WarrenWs`** — WebSocket client with v0.1 token + v0.2 keypair auth, AES-256-GCM encrypted transport, auto-reconnect with exponential backoff
- **`WarrenHttp`** — REST client for health, devices, sessions, config, pairing, and discovery endpoints
- **`Emitter`** — lightweight typed event emitter (no Node.js dependency)
- Crypto layer using `@noble/ciphers` + `@noble/hashes` for synchronous, cross-platform crypto (Bun + Node.js)

### Usage

```ts
import { Warren } from '@warren/sdk'

const warren = new Warren({ host: 'localhost', port: 9470, token: '...' })
await warren.connect()

const session = await warren.createSession({ shell: '/bin/zsh' })
session.onData((data) => process.stdout.write(data))
session.write('ls -la\n')
session.resize(120, 40)
await session.kill()

const devices = await warren.listDevices()
const health = await warren.getHealth()

warren.disconnect()
```

## Test plan

- [x] 26 tests pass (unit + integration): `bun run --filter @warren/sdk test`
- [x] TypeScript typecheck: `bun run --filter @warren/sdk typecheck`
- [x] Biome lint + format: `bun run --filter @warren/sdk lint`
- [ ] Manual: start a Warren server and connect with the SDK
- [ ] Verify auto-reconnect behavior on disconnect
- [ ] Verify encrypted transport with keypair auth

Closes #21